### PR TITLE
fix: Claude session resume, inherited env markers, invisible icons

### DIFF
--- a/src-app/src/agent_launcher.rs
+++ b/src-app/src/agent_launcher.rs
@@ -836,6 +836,9 @@ mod tests {
             "-x",
             "x; rm -rf ~",
             "$(reboot)",
+            // A bare space would split into a second, positional argument
+            // even without any shell metacharacter.
+            "abc def",
         ] {
             assert_eq!(
                 TerminalAgent::ClaudeCode.command_with_session(&cfg, SessionBinding::Mint(hostile)),

--- a/src-app/src/agent_launcher.rs
+++ b/src-app/src/agent_launcher.rs
@@ -18,6 +18,50 @@ use std::time::{Duration, Instant};
 
 use paneflow_config::schema::PaneFlowConfig;
 
+/// How a thread's forced agent session id reaches the CLI.
+///
+/// Claude Code separates *minting* a session from *resuming* one, and the two
+/// are not interchangeable (verified against Claude Code 2.1.232):
+///
+/// - `--session-id <uuid>` - "Use a specific session ID for the conversation".
+///   Names a **new** conversation. Once that id has a session file on disk the
+///   CLI refuses the launch with
+///   `Error: Session ID <uuid> is already in use.`
+/// - `-r, --resume <uuid>` - "Resume a conversation by session ID". The only
+///   way back into an existing session.
+///
+/// A thread therefore mints on the launch that creates its session and
+/// resumes on every launch after that. Passing `--session-id` unconditionally
+/// works on first mount and breaks on every reopen, which is what
+/// [`SessionBinding::resolve`] exists to prevent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionBinding<'a> {
+    /// No forced id: bare shell, non-Claude agent, or a thread that never
+    /// minted one.
+    Unbound,
+    /// The id has no session file yet - mint it (`--session-id <uuid>`).
+    Mint(&'a str),
+    /// The id already has a session file - reattach (`--resume <uuid>`).
+    Resume(&'a str),
+}
+
+impl<'a> SessionBinding<'a> {
+    /// Resolve the binding for `session_id` in `cwd` by asking the on-disk
+    /// session store whether the CLI has seen this id before.
+    ///
+    /// Disk is the authority rather than any in-memory "have we launched yet"
+    /// flag: it stays correct when the user deletes a session behind
+    /// PaneFlow's back, when `session.json` is restored onto a different
+    /// machine, and when the CLI never got far enough to write the file.
+    pub fn resolve(session_id: Option<&'a str>, cwd: &str) -> Self {
+        match session_id {
+            Some(id) if crate::claude_sessions::session_file_exists(cwd, id) => Self::Resume(id),
+            Some(id) => Self::Mint(id),
+            None => Self::Unbound,
+        }
+    }
+}
+
 /// One of the CLI coding agents Paneflow can launch in a terminal.
 ///
 /// Distinct from [`paneflow_acp::AgentKind`] (Claude/Codex only, the ACP
@@ -327,10 +371,10 @@ impl TerminalAgent {
     }
 
     /// Whether the CLI accepts a caller-forced session UUID via
-    /// `--session-id <uuid>`. Only Claude Code does (verified against the
-    /// CLI: a fresh id starts a new session, an existing id resumes +
-    /// appends, so a stable per-thread id is safe across restarts). Other
-    /// agents fall back to the newest-session heuristic in the title
+    /// `--session-id <uuid>`. Only Claude Code does, and only for a *fresh*
+    /// id - an id that already has a session file must be reattached with
+    /// `--resume` instead. See [`SessionBinding`] for the full contract.
+    /// Other agents fall back to the newest-session heuristic in the title
     /// backfill.
     pub fn supports_forced_session_id(self) -> bool {
         matches!(self, TerminalAgent::ClaudeCode)
@@ -355,21 +399,27 @@ impl TerminalAgent {
         }
     }
 
-    /// Like [`Self::command`] but injects a forced `--session-id <uuid>` for
-    /// Claude when `session_id` is `Some` and passes the PTY allow-list. The
-    /// flag lands right after the binary so it composes with the optional
+    /// Like [`Self::command`] but injects the session flag selected by
+    /// `binding` for Claude when its id passes the PTY allow-list:
+    /// `--session-id <uuid>` to mint, `--resume <uuid>` to reattach. The flag
+    /// lands right after the binary so it composes with the optional
     /// `--permission-mode bypassPermissions` already baked into the base
-    /// command. Any other agent (or `None`) yields the plain base command.
-    fn command_with_session(self, config: &PaneFlowConfig, session_id: Option<&str>) -> String {
+    /// command. Any other agent (or [`SessionBinding::Unbound`]) yields the
+    /// plain base command.
+    fn command_with_session(self, config: &PaneFlowConfig, binding: SessionBinding<'_>) -> String {
         if self != TerminalAgent::ClaudeCode {
             return self.command(config);
         }
-        let Some(id) = session_id.filter(|id| crate::agent_sessions::is_valid_session_id(id))
-        else {
-            return self.command(config);
+        let (flag, id) = match binding {
+            SessionBinding::Unbound => return self.command(config),
+            SessionBinding::Mint(id) => ("--session-id", id),
+            SessionBinding::Resume(id) => ("--resume", id),
         };
+        if !crate::agent_sessions::is_valid_session_id(id) {
+            return self.command(config);
+        }
         let mut spec = self.launch_spec(config);
-        spec.insert_arg(0, "--session-id");
+        spec.insert_arg(0, flag);
         spec.insert_arg(1, id);
         spec.render_shell_command()
     }
@@ -378,17 +428,18 @@ impl TerminalAgent {
     /// configured shell (`clear`, `cls`, or `Clear-Host`) so the agent TUI owns
     /// the viewport from the first frame on every platform.
     pub fn launch_command(self, config: &PaneFlowConfig) -> String {
-        self.launch_command_with_session(config, None)
+        self.launch_command_with_session(config, SessionBinding::Unbound)
     }
 
-    /// [`Self::launch_command`] with a forced agent session id (Claude
-    /// only - see [`Self::command_with_session`]). The Agents-view PTY
-    /// mount passes the thread's bound `session_id` here so the live thread
-    /// maps 1:1 to its on-disk session file.
+    /// [`Self::launch_command`] with a bound agent session (Claude only - see
+    /// [`Self::command_with_session`]). The Agents-view PTY mount resolves
+    /// the thread's `session_id` through [`SessionBinding::resolve`] and
+    /// passes the result here, so the live thread maps 1:1 to its on-disk
+    /// session file on the first launch and reattaches to it on every reopen.
     pub fn launch_command_with_session(
         self,
         config: &PaneFlowConfig,
-        session_id: Option<&str>,
+        binding: SessionBinding<'_>,
     ) -> String {
         // US-042: trim + drop-empty exactly like the PTY session does when it
         // resolves the shell (`pty_session.rs:442`). A config such as
@@ -400,7 +451,7 @@ impl TerminalAgent {
             .as_deref()
             .map(str::trim)
             .filter(|s| !s.is_empty());
-        crate::terminal::shell::clear_then(&self.command_with_session(config, session_id), shell)
+        crate::terminal::shell::clear_then(&self.command_with_session(config, binding), shell)
     }
 
     /// Visible variants for the given config, in display order. Drives
@@ -730,9 +781,27 @@ mod tests {
     #[test]
     fn claude_session_id_is_injected_after_binary() {
         let cfg = PaneFlowConfig::default();
-        let cmd = TerminalAgent::ClaudeCode.command_with_session(&cfg, Some(SAMPLE_UUID));
+        let cmd =
+            TerminalAgent::ClaudeCode.command_with_session(&cfg, SessionBinding::Mint(SAMPLE_UUID));
         assert_eq!(cmd, format!("claude --session-id {SAMPLE_UUID}"));
         // Leading token stays `claude` (the PATH-probe invariant).
+        assert_eq!(cmd.split_whitespace().next(), Some("claude"));
+    }
+
+    #[test]
+    fn claude_resume_reattaches_instead_of_minting() {
+        // Regression: reopening a thread after a restart used to re-send
+        // `--session-id <existing uuid>`, which Claude Code rejects with
+        // `Error: Session ID <uuid> is already in use.` An id that already
+        // has a session file must go out as `--resume`.
+        let cfg = PaneFlowConfig::default();
+        let cmd = TerminalAgent::ClaudeCode
+            .command_with_session(&cfg, SessionBinding::Resume(SAMPLE_UUID));
+        assert_eq!(cmd, format!("claude --resume {SAMPLE_UUID}"));
+        assert!(
+            !cmd.contains("--session-id"),
+            "resume must never re-mint the id"
+        );
         assert_eq!(cmd.split_whitespace().next(), Some("claude"));
     }
 
@@ -742,17 +811,25 @@ mod tests {
             claude_code_bypass_permissions: Some(true),
             ..Default::default()
         };
-        let cmd = TerminalAgent::ClaudeCode.command_with_session(&cfg, Some(SAMPLE_UUID));
+        let mint =
+            TerminalAgent::ClaudeCode.command_with_session(&cfg, SessionBinding::Mint(SAMPLE_UUID));
         assert_eq!(
-            cmd,
+            mint,
             format!("claude --session-id {SAMPLE_UUID} --permission-mode bypassPermissions")
+        );
+        let resume = TerminalAgent::ClaudeCode
+            .command_with_session(&cfg, SessionBinding::Resume(SAMPLE_UUID));
+        assert_eq!(
+            resume,
+            format!("claude --resume {SAMPLE_UUID} --permission-mode bypassPermissions")
         );
     }
 
     #[test]
     fn invalid_session_id_is_not_injected() {
         // Flag-shaped / shell-meta ids fail the allow-list, so a tampered
-        // session.json can never smuggle a second argument into the launch.
+        // session.json can never smuggle a second argument into the launch -
+        // on either arm.
         let cfg = PaneFlowConfig::default();
         for hostile in [
             "--dangerously-skip-permissions",
@@ -761,11 +838,35 @@ mod tests {
             "$(reboot)",
         ] {
             assert_eq!(
-                TerminalAgent::ClaudeCode.command_with_session(&cfg, Some(hostile)),
+                TerminalAgent::ClaudeCode.command_with_session(&cfg, SessionBinding::Mint(hostile)),
                 "claude",
-                "hostile id {hostile:?} must be dropped"
+                "hostile id {hostile:?} must be dropped when minting"
+            );
+            assert_eq!(
+                TerminalAgent::ClaudeCode
+                    .command_with_session(&cfg, SessionBinding::Resume(hostile)),
+                "claude",
+                "hostile id {hostile:?} must be dropped when resuming"
             );
         }
+    }
+
+    #[test]
+    fn session_binding_resolves_unbound_without_an_id() {
+        assert_eq!(
+            SessionBinding::resolve(None, "/tmp/paneflow-does-not-exist"),
+            SessionBinding::Unbound
+        );
+    }
+
+    #[test]
+    fn session_binding_mints_when_no_session_file_exists() {
+        // No project dir for this cwd, so the id cannot have a session file
+        // and the first launch must mint it.
+        assert_eq!(
+            SessionBinding::resolve(Some(SAMPLE_UUID), "/tmp/paneflow-no-such-project-dir"),
+            SessionBinding::Mint(SAMPLE_UUID)
+        );
     }
 
     #[test]
@@ -778,21 +879,26 @@ mod tests {
     #[test]
     fn non_claude_ignores_forced_session_id() {
         let cfg = PaneFlowConfig::default();
-        assert_eq!(
-            TerminalAgent::Codex.command_with_session(&cfg, Some(SAMPLE_UUID)),
-            "codex"
-        );
-        assert_eq!(
-            TerminalAgent::OpenCode.command_with_session(&cfg, Some(SAMPLE_UUID)),
-            "opencode"
-        );
+        for binding in [
+            SessionBinding::Mint(SAMPLE_UUID),
+            SessionBinding::Resume(SAMPLE_UUID),
+        ] {
+            assert_eq!(
+                TerminalAgent::Codex.command_with_session(&cfg, binding),
+                "codex"
+            );
+            assert_eq!(
+                TerminalAgent::OpenCode.command_with_session(&cfg, binding),
+                "opencode"
+            );
+        }
     }
 
     #[test]
     fn claude_without_session_id_is_bare_command() {
         let cfg = PaneFlowConfig::default();
         assert_eq!(
-            TerminalAgent::ClaudeCode.command_with_session(&cfg, None),
+            TerminalAgent::ClaudeCode.command_with_session(&cfg, SessionBinding::Unbound),
             "claude"
         );
     }

--- a/src-app/src/app/agents_sidebar/mod.rs
+++ b/src-app/src/app/agents_sidebar/mod.rs
@@ -1277,10 +1277,25 @@ fn hover_actions_cluster(
         .rounded(px(4.))
         .bg(resting_background)
         .text_color(ui.muted)
-        .animated_hover(move |style, delta| {
-            style
+        // The icon is emitted from inside the hover closure, exactly like the
+        // "New project" button above. `svg()` paints a monochrome mask in its
+        // OWN style's text color and does not inherit the parent's, so an
+        // `svg()` child with no `text_color` of its own renders as nothing:
+        // the button, its tooltip and its click target all work while the
+        // glyph is simply invisible. Re-emitting it per frame is also what
+        // lets the icon animate with the button instead of staying flat.
+        .animated_hover_element(move |button, delta| {
+            let icon_color = lerp_color(ui.muted, ui.text, delta);
+            button
+                .style()
                 .bg(lerp_color(resting_background, hover_background, delta))
-                .text_color(lerp_color(ui.muted, ui.text, delta));
+                .text_color(icon_color);
+            button.extend([svg()
+                .size(px(12.))
+                .flex_none()
+                .path("icons/trash.svg")
+                .text_color(icon_color)
+                .into_any_element()]);
         })
         .tooltip(crate::ui_primitives::text_tooltip("Delete"))
         .on_click(cx.listener(move |this, _: &ClickEvent, _w, cx| {
@@ -1288,8 +1303,7 @@ fn hover_actions_cluster(
             // cluster flips to a red "Delete" button (see the `armed` branch).
             this.arm_delete_for_target(target, cx);
             cx.stop_propagation();
-        }))
-        .child(svg().size(px(12.)).flex_none().path("icons/trash.svg"));
+        }));
 
     div()
         .absolute()

--- a/src-app/src/app/agents_view_actions.rs
+++ b/src-app/src/app/agents_view_actions.rs
@@ -1124,6 +1124,10 @@ impl PaneFlowApp {
         // the launch command below so the live PTY binds 1:1 to its on-disk
         // session file (and resumes the same session after a restart).
         let bound_session = thread.session_id.clone();
+        // Resolved against the on-disk session store below: the first launch
+        // mints the id, every reopen reattaches to it. See
+        // [`crate::agent_launcher::SessionBinding`].
+        let thread_cwd = thread.cwd.clone();
         // Explicit per-thread agent wins; legacy `Agent`-kind chat rows
         // fall back to their stored ACP agent so reopening them launches
         // the same CLI in a terminal. Plain Terminal Threads stay a bare
@@ -1156,8 +1160,11 @@ impl PaneFlowApp {
         // Cache hits (in-session re-selection) skip this, so a running
         // agent is never relaunched on navigation.
         if let Some(agent) = terminal_agent {
-            let cmd =
-                agent.launch_command_with_session(&self.cached_config, bound_session.as_deref());
+            let binding = crate::agent_launcher::SessionBinding::resolve(
+                bound_session.as_deref(),
+                &thread_cwd,
+            );
+            let cmd = agent.launch_command_with_session(&self.cached_config, binding);
             view.read(cx).send_command(&cmd);
         }
         // Mirror Zed's `AgentTerminal::refresh_terminal_metadata`

--- a/src-app/src/claude_sessions.rs
+++ b/src-app/src/claude_sessions.rs
@@ -81,10 +81,30 @@ pub fn slug_for_cwd(cwd: &str) -> String {
 
 /// Compute the absolute path of `~/.claude/projects/<slug>/`. Returns
 /// `None` when `dirs::home_dir()` fails (no `$HOME` / `%USERPROFILE%`).
+///
+/// A trailing separator is normalized away first. Claude derives its own slug
+/// from the agent process's cwd, which never carries one, so `/a/b/` has to
+/// resolve to the same directory as `/a/b` - otherwise the lookup misses a
+/// directory that exists, and [`session_file_exists`] reports "no session"
+/// for a session that is very much there, sending `--session-id` for an id
+/// the CLI already knows.
 pub fn project_dir_for_cwd(cwd: &str) -> Option<PathBuf> {
     let home = dirs::home_dir()?;
-    let slug = slug_for_cwd(cwd);
+    let slug = slug_for_cwd(normalize_cwd_for_slug(cwd));
     Some(home.join(".claude").join("projects").join(slug))
+}
+
+/// Strip trailing path separators, unless that would reduce `cwd` to a bare
+/// root. `/` is all separator and `C:\` is a drive root: trimming those
+/// changes the slug (`-` → ``, `C--` → `C-`) instead of normalizing it, and
+/// Claude keeps them intact.
+fn normalize_cwd_for_slug(cwd: &str) -> &str {
+    let trimmed = cwd.trim_end_matches(['/', '\\']);
+    if trimmed.is_empty() || trimmed.ends_with(':') {
+        cwd
+    } else {
+        trimmed
+    }
 }
 
 /// Whether the CLI already holds a session file for `session_id` under
@@ -98,8 +118,11 @@ pub fn project_dir_for_cwd(cwd: &str) -> Option<PathBuf> {
 /// Unlike the readers below this is a single `stat` - it never walks or
 /// parses the project dir - so it is cheap enough for the PTY-mount path on
 /// the GPUI main thread. Ids are filtered through
-/// [`crate::agent_sessions::is_valid_session_id`] first, which rejects `/`,
-/// `\` and `.`, so a tampered `session.json` cannot escape the project dir.
+/// [`crate::agent_sessions::is_valid_session_id`] first, whose allow-list
+/// admits only ASCII alphanumerics plus `-`/`_` (and never a leading `-`):
+/// no separator, no `.`, no space, no shell metacharacter. A tampered
+/// `session.json` can therefore neither escape the project dir here nor
+/// smuggle an extra argument into the launch command.
 pub fn session_file_exists(cwd: &str, session_id: &str) -> bool {
     if !crate::agent_sessions::is_valid_session_id(session_id) {
         return false;
@@ -556,6 +579,49 @@ mod tests {
         // Verified against a real install: Claude Code stores `C:\dev\paneflow`
         // sessions under `~/.claude/projects/C--dev-paneflow/`.
         assert_eq!(slug_for_cwd("C:\\dev\\paneflow"), "C--dev-paneflow");
+    }
+
+    #[test]
+    fn trailing_separator_resolves_to_the_same_project_dir() {
+        // Claude's own cwd never carries a trailing separator, so a stored
+        // `thread.cwd` that does must still find the directory that exists.
+        // Getting this wrong makes `session_file_exists` report "no session"
+        // for a live one, which re-sends `--session-id` and reproduces
+        // `Session ID <uuid> is already in use`.
+        assert_eq!(
+            project_dir_for_cwd("/home/alice/myapp/"),
+            project_dir_for_cwd("/home/alice/myapp")
+        );
+        assert_eq!(
+            project_dir_for_cwd("/home/alice/myapp///"),
+            project_dir_for_cwd("/home/alice/myapp")
+        );
+        assert_eq!(
+            project_dir_for_cwd("C:\\dev\\paneflow\\"),
+            project_dir_for_cwd("C:\\dev\\paneflow")
+        );
+    }
+
+    #[test]
+    fn bare_roots_keep_their_slug() {
+        // All-separator paths are not normalized: trimming would change the
+        // slug rather than canonicalize it.
+        assert_eq!(normalize_cwd_for_slug("/"), "/");
+        assert_eq!(normalize_cwd_for_slug("C:\\"), "C:\\");
+        assert_eq!(slug_for_cwd(normalize_cwd_for_slug("/")), "-");
+        assert_eq!(slug_for_cwd(normalize_cwd_for_slug("C:\\")), "C--");
+    }
+
+    #[test]
+    fn session_file_exists_rejects_ids_outside_the_allow_list() {
+        // The allow-list gate runs before any path join, so no id can escape
+        // the project dir or reach the filesystem as a traversal.
+        for hostile in ["../../etc/passwd", "a/b", "a\\b", "with space", ".hidden"] {
+            assert!(
+                !session_file_exists("/home/alice/myapp", hostile),
+                "hostile id {hostile:?} must be rejected before the path join"
+            );
+        }
     }
 
     #[test]

--- a/src-app/src/claude_sessions.rs
+++ b/src-app/src/claude_sessions.rs
@@ -87,6 +87,28 @@ pub fn project_dir_for_cwd(cwd: &str) -> Option<PathBuf> {
     Some(home.join(".claude").join("projects").join(slug))
 }
 
+/// Whether the CLI already holds a session file for `session_id` under
+/// `cwd`'s project dir.
+///
+/// Drives the mint-vs-resume choice in
+/// [`crate::agent_launcher::SessionBinding::resolve`]: `--session-id` is only
+/// legal for an id the CLI has never seen, so a thread may only pass it on
+/// the launch that creates the session.
+///
+/// Unlike the readers below this is a single `stat` - it never walks or
+/// parses the project dir - so it is cheap enough for the PTY-mount path on
+/// the GPUI main thread. Ids are filtered through
+/// [`crate::agent_sessions::is_valid_session_id`] first, which rejects `/`,
+/// `\` and `.`, so a tampered `session.json` cannot escape the project dir.
+pub fn session_file_exists(cwd: &str, session_id: &str) -> bool {
+    if !crate::agent_sessions::is_valid_session_id(session_id) {
+        return false;
+    }
+    project_dir_for_cwd(cwd)
+        .map(|dir| dir.join(format!("{session_id}.jsonl")).is_file())
+        .unwrap_or(false)
+}
+
 fn project_snapshot_mtime(project_dir: &Path) -> Option<SystemTime> {
     let mut latest = fs::metadata(project_dir)
         .ok()

--- a/src-app/src/terminal/pty_session.rs
+++ b/src-app/src/terminal/pty_session.rs
@@ -61,7 +61,33 @@ use super::ghostty_session::{
 /// [`paneflow_config::TerminalConfig::resolved_scrollback_lines`].
 const DEFAULT_SCROLLBACK_LINES: usize = TerminalConfig::DEFAULT_SCROLLBACK_LINES;
 const PTY_DRAIN_ON_EXIT: bool = true;
-const CLAUDECODE_ENV: &str = "CLAUDECODE";
+/// Identity and credential markers Claude Code exports into the processes it
+/// spawns. A pane that inherits them makes the agent running inside it believe
+/// it is a *nested child* of the Claude Code session that launched Paneflow.
+///
+/// The consequence is silent and expensive: on inheriting
+/// `CLAUDE_CODE_CHILD_SESSION` the agent turns transcript saving off, so its
+/// conversation never lands in `~/.claude/projects/<slug>/<uuid>.jsonl`. The
+/// thread then has no session file to come back to, and reopening it after a
+/// restart starts an empty conversation instead of resuming - the failure only
+/// announces itself as one dim line at the bottom of the agent's own TUI.
+///
+/// The messaging socket/token pair is stripped for a second reason: it is a
+/// live credential for the launching session's IPC channel, and no agent
+/// spawned in a pane has any business holding it.
+///
+/// A pane must always look like a fresh terminal, never like a continuation of
+/// whatever spawned Paneflow. Inheriting is the only way these reach the child
+/// - Paneflow itself namespaces everything it sets under `PANEFLOW_*`.
+const INHERITED_AGENT_SESSION_ENV: &[&str] = &[
+    "CLAUDECODE",
+    "CLAUDE_CODE_CHILD_SESSION",
+    "CLAUDE_CODE_SESSION_ID",
+    "CLAUDE_CODE_ENTRYPOINT",
+    "CLAUDE_CODE_EXECPATH",
+    "CLAUDE_CODE_MESSAGING_SOCKET",
+    "CLAUDE_CODE_MESSAGING_TOKEN",
+];
 const MAX_PENDING_CLIPBOARD_OPS: usize = 8;
 
 /// Read the user's configured scrollback length, clamped to the
@@ -4052,8 +4078,14 @@ fn is_loader_influencing_env_key(key: &str) -> bool {
     key.starts_with("LD_") || key.starts_with("DYLD_")
 }
 
+/// True if `key` is one of the launching agent session's identity/credential
+/// markers - see [`INHERITED_AGENT_SESSION_ENV`].
+fn is_inherited_agent_session_env_key(key: &str) -> bool {
+    INHERITED_AGENT_SESSION_ENV.contains(&key)
+}
+
 fn is_forbidden_child_env_key(key: &str) -> bool {
-    key == CLAUDECODE_ENV || is_loader_influencing_env_key(key)
+    is_inherited_agent_session_env_key(key) || is_loader_influencing_env_key(key)
 }
 
 /// True if `key` is a well-formed environment variable name safe to insert into
@@ -4278,7 +4310,9 @@ fn assemble_pty_env(
         }
     }
 
-    env.remove(CLAUDECODE_ENV);
+    // Runs after the user/session merge so neither an inherited value nor a
+    // hand-written `terminal.env` entry can put these back.
+    env.retain(|k, _| !is_inherited_agent_session_env_key(k));
     reassert_paneflow_bin_dir_first(&mut env);
 
     env
@@ -5827,6 +5861,40 @@ mod tests {
             "CLAUDECODE must never reach agent child processes"
         );
         assert_eq!(env.get("KEEP_ME").map(String::as_str), Some("yes"));
+    }
+
+    #[test]
+    fn inherited_agent_session_markers_are_dropped_from_child_env() {
+        // Launching Paneflow from inside an agent session (or from an IDE
+        // terminal that carries these) otherwise leaks the parent session's
+        // identity into every pane. `CLAUDE_CODE_CHILD_SESSION` in particular
+        // makes the agent disable transcript saving, so its conversation never
+        // reaches `~/.claude/projects` and the thread cannot be resumed after a
+        // restart.
+        let mut base = HashMap::new();
+        let mut user = HashMap::new();
+        for key in INHERITED_AGENT_SESSION_ENV {
+            base.insert((*key).to_string(), "inherited".to_string());
+            // Also offered through `terminal.env`: the strip runs after the
+            // merge, so a hand-written config cannot reinstate them either.
+            user.insert((*key).to_string(), "from-config".to_string());
+        }
+        user.insert("KEEP_ME".to_string(), "yes".to_string());
+
+        let env = assemble_pty_env(base, 1, 1, Some(user));
+
+        for key in INHERITED_AGENT_SESSION_ENV {
+            assert_eq!(
+                env.get(*key),
+                None,
+                "{key} must never reach an agent spawned in a pane"
+            );
+        }
+        assert_eq!(
+            env.get("KEEP_ME").map(String::as_str),
+            Some("yes"),
+            "a benign var alongside the markers must still pass through"
+        );
     }
 
     // US-019: foreground_command degrades gracefully (no panic, None) on a

--- a/src-app/src/ui_primitives.rs
+++ b/src-app/src/ui_primitives.rs
@@ -580,17 +580,28 @@ fn filter_pill_with_clear_cursor(
                 .rounded(px(3.))
                 .cursor(clear_cursor)
                 .text_color(ui.muted)
-                .animated_hover(move |style, delta| {
-                    style
+                // Emitted from inside the hover closure: `svg()` paints its
+                // mask in its own style's text color and never inherits the
+                // parent's, so a bare `svg()` child renders as nothing - the
+                // clear button stays clickable while its glyph is invisible.
+                .animated_hover_element(move |button, delta| {
+                    let icon_color = lerp_color(ui.muted, ui.text, delta);
+                    button
+                        .style()
                         .bg(lerp_color(
                             with_alpha(ui.text, 0.0),
                             with_alpha(ui.text, 0.10),
                             delta,
                         ))
-                        .text_color(lerp_color(ui.muted, ui.text, delta));
+                        .text_color(icon_color);
+                    button.extend([svg()
+                        .size(px(10.))
+                        .flex_none()
+                        .path("icons/close.svg")
+                        .text_color(icon_color)
+                        .into_any_element()]);
                 })
-                .on_click(on_clear)
-                .child(svg().size(px(10.)).flex_none().path("icons/close.svg")),
+                .on_click(on_clear),
         );
     }
     field

--- a/src-app/tests/svg_icon_color_policy.rs
+++ b/src-app/tests/svg_icon_color_policy.rs
@@ -1,0 +1,92 @@
+#![allow(
+    clippy::panic,
+    reason = "integration test setup failures need contextual diagnostics"
+)]
+
+//! Every `svg()` icon must set its own `text_color`.
+//!
+//! GPUI's `svg()` rasterizes to a monochrome alpha mask painted in the colour
+//! taken from that element's *own* style. It does not inherit the parent's
+//! text colour the way a text glyph does, so an `svg()` with no `text_color`
+//! of its own paints nothing at all.
+//!
+//! That failure is invisible to every other kind of test, and nearly invisible
+//! in review: the button still lays out, still hit-tests, still shows its
+//! tooltip and still runs its click handler. Only the glyph is missing, which
+//! is exactly how the sidebar's delete icon and the text fields' clear icon
+//! both shipped as blank squares - a button users could not see but could
+//! still press.
+//!
+//! Enforcing it here rather than by convention keeps the whole class from
+//! coming back, since nothing else in the suite can observe a painted pixel.
+
+use std::path::{Path, PathBuf};
+
+/// Walk `dir` and return every `.rs` file under it.
+fn rust_sources(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        panic!("failed to read source dir {}", dir.display());
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            out.extend(rust_sources(&path));
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            out.push(path);
+        }
+    }
+    out
+}
+
+/// The builder chain that starts at `start` in `src`, ending at the statement
+/// or argument terminator. Good enough to tell "this `svg()` sets a colour"
+/// from "this one does not": both `.path(..)` and `.text_color(..)` sit on the
+/// same chain, and a chain never spans a `;`.
+fn builder_chain(src: &str, start: usize) -> &str {
+    let rest = &src[start..];
+    let end = rest.find(';').unwrap_or(rest.len());
+    &rest[..end]
+}
+
+#[test]
+fn every_svg_icon_sets_its_own_text_color() {
+    let src_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut offenders = Vec::new();
+    let mut checked = 0usize;
+
+    for file in rust_sources(&src_dir) {
+        let Ok(source) = std::fs::read_to_string(&file) else {
+            panic!("failed to read {}", file.display());
+        };
+        for (offset, _) in source.match_indices("svg()") {
+            let chain = builder_chain(&source, offset);
+            // Only chains that actually name an asset paint an icon; a bare
+            // `svg()` handed to a helper is coloured by that helper.
+            if !chain.contains(".path(") {
+                continue;
+            }
+            checked += 1;
+            if chain.contains(".text_color(") {
+                continue;
+            }
+            let line = source[..offset].matches('\n').count() + 1;
+            offenders.push(format!("{}:{line}", file.display()));
+        }
+    }
+
+    assert!(
+        checked > 0,
+        "found no `svg().path(..)` call sites at all - the scan is broken, \
+         not the code"
+    );
+    assert!(
+        offenders.is_empty(),
+        "these `svg()` icons set no `text_color` and will paint as blank \
+         space:\n  {}\n\nGPUI paints an svg mask in its own style's colour and \
+         never inherits the parent's. Set `.text_color(..)` on the `svg()` \
+         itself - see the delete button in `agents_sidebar/mod.rs` for the \
+         hover-animated form.",
+        offenders.join("\n  ")
+    );
+}


### PR DESCRIPTION
Four independent fixes found while running Paneflow on macOS. Each carries tests; `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check` are clean.

### Reopening a thread re-mints its session

`--session-id` names a *new* conversation — an id that already has a transcript is rejected with `Error: Session ID <uuid> is already in use.` Reopening an Agents thread re-sent `--session-id`, so a thread could never come back after a restart. A `SessionBinding` enum now resolves mint-vs-resume against the on-disk transcript. Verified against Claude Code 2.1.232.

### Project slug ignores a trailing separator

`slug_for_cwd("/a/b/")` yields `-a-b-`, but the directory Claude creates is `-a-b`. The lookup missed a project dir that exists, which defeats the fix above and also left the sessions sidebar empty for such a cwd. Normalized in `project_dir_for_cwd`; bare roots (`/`, `C:\`) keep their form, since trimming those changes the slug rather than canonicalizing it.

### Inherited agent-session env markers reach panes

`CLAUDECODE` was already stripped, `CLAUDE_CODE_CHILD_SESSION` was not. An agent that inherits it treats itself as a nested child session and turns transcript saving off, so its conversation never reaches `~/.claude/projects` and the thread has nothing to resume. This hits anyone launching Paneflow from a context carrying the markers — an agent session, an IDE terminal — not just a from-source run. The messaging socket/token pair is stripped too: it is a live credential for the launching session's IPC channel.

### Invisible delete and clear icons — fixes #27

`svg()` paints its mask in the colour from its own style and never inherits the parent's. Two call sites set the colour on the wrapping button only, so the mask painted nothing: the per-thread delete button and the clear button inside text fields. The button still laid out, hit-tested, showed its tooltip and ran its handler — only the glyph was missing.

#27 is filed as `[windows]`, but the cause is platform-independent; I hit it on macOS. Both sites now emit the icon inside the hover closure with the colour applied to the `svg()` itself, matching the "New project" button that was already doing it correctly.

Added a source-policy test next to the existing `dependency_source_policy`, since nothing else in the suite can observe a painted pixel. It was verified to fail, naming the exact file and line, when either fix is reverted.

---

Happy to split this into separate PRs if you prefer. A follow-up branch adds "open a session from history as a thread" for Agents mode, which builds on the first fix — I'll send it separately once this lands.