### PR TITLE
feat(agents): name tabs after the work running in them

### DIFF
--- a/.github/actions/linux-build-deps/action.yml
+++ b/.github/actions/linux-build-deps/action.yml
@@ -1,0 +1,38 @@
+name: Linux build dependencies
+description: >-
+  Install the GPUI / Blade / fontconfig system libraries every Linux cargo job
+  in this repository needs. Kept as a composite action so the package list has
+  a single source of truth instead of one copy per job.
+
+inputs:
+  extra-packages:
+    description: >-
+      Space-separated additional apt packages to install in the same
+      transaction (packaging tools, inspection tools, ...).
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Install system dependencies
+      shell: bash
+      env:
+        EXTRA_PACKAGES: ${{ inputs.extra-packages }}
+      run: |
+        set -euo pipefail
+        sudo apt-get update
+        # shellcheck disable=SC2086 # word splitting is the point for EXTRA_PACKAGES
+        sudo apt-get install -y \
+          libfontconfig1-dev \
+          libfreetype6-dev \
+          libvulkan-dev \
+          libwayland-dev \
+          libx11-dev \
+          libxcb-render0-dev \
+          libxcb-shape0-dev \
+          libxcb-xfixes0-dev \
+          libxcb1-dev \
+          libxkbcommon-dev \
+          libxkbcommon-x11-dev \
+          $EXTRA_PACKAGES

--- a/.github/workflows/libghostty-linux.yml
+++ b/.github/workflows/libghostty-linux.yml
@@ -3,84 +3,22 @@ name: libghostty Linux
 on:
   push:
     branches: [main]
-    paths:
-      - ".github/workflows/libghostty-linux.yml"
-      - ".github/workflows/release.yml"
-      - "Cargo.lock"
-      - "Cargo.toml"
-      - "LICENSE"
-      - "README.md"
-      - "assets/icons/**"
-      - "assets/io.github.arthurdev44.paneflow.metainfo.xml"
-      - "assets/paneflow.desktop"
-      - "crates/paneflow-config/**"
-      - "crates/paneflow-ghostty-smoke/**"
-      - "crates/paneflow-libghostty-sys/**"
-      - "crates/paneflow-terminal-ghostty/**"
-      - "debian/changelog"
-      - "deny.toml"
-      - "docs/user/configuration/schema.md"
-      - "docs/user/settings.md"
-      - "fuzz/**"
-      - "native/libghostty/**"
-      - "packaging/AppRun"
-      - "packaging/debian/**"
-      - "packaging/paneflow-release.asc"
-      - "packaging/rpm/**"
-      - "schemas/paneflow.schema.json"
-      - "scripts/*libghostty*"
-      - "scripts/bundle-appimage.sh"
-      - "scripts/bundle-tarball.sh"
-      - "src-app/Cargo.toml"
-      - "src-app/src/app/**"
-      - "src-app/src/keybindings/**"
-      - "src-app/src/layout/**"
-      - "src-app/src/search.rs"
-      - "src-app/src/terminal/**"
-      - "src-app/tests/dependency_source_policy.rs"
   pull_request:
     branches: [main]
-    paths:
-      - ".github/workflows/libghostty-linux.yml"
-      - ".github/workflows/release.yml"
-      - "Cargo.lock"
-      - "Cargo.toml"
-      - "LICENSE"
-      - "README.md"
-      - "assets/icons/**"
-      - "assets/io.github.arthurdev44.paneflow.metainfo.xml"
-      - "assets/paneflow.desktop"
-      - "crates/paneflow-config/**"
-      - "crates/paneflow-ghostty-smoke/**"
-      - "crates/paneflow-libghostty-sys/**"
-      - "crates/paneflow-terminal-ghostty/**"
-      - "debian/changelog"
-      - "deny.toml"
-      - "docs/user/configuration/schema.md"
-      - "docs/user/settings.md"
-      - "fuzz/**"
-      - "native/libghostty/**"
-      - "packaging/AppRun"
-      - "packaging/debian/**"
-      - "packaging/paneflow-release.asc"
-      - "packaging/rpm/**"
-      - "schemas/paneflow.schema.json"
-      - "scripts/*libghostty*"
-      - "scripts/bundle-appimage.sh"
-      - "scripts/bundle-tarball.sh"
-      - "src-app/Cargo.toml"
-      - "src-app/src/app/**"
-      - "src-app/src/keybindings/**"
-      - "src-app/src/layout/**"
-      - "src-app/src/search.rs"
-      - "src-app/src/terminal/**"
-      - "src-app/tests/dependency_source_policy.rs"
   schedule:
     - cron: "17 1 * * *"
   workflow_dispatch: {}
 
 permissions:
   contents: read
+
+# Same posture as run_tests.yml: -e fail-on-error, -u error-on-unset,
+# -o pipefail propagate pipe failures. Several steps below build a path
+# through `find ... -print -quit` and pipe it, which silently passed a
+# missing artifact through before pipefail was on.
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -93,8 +31,59 @@ env:
   ZIG_VERSION: 0.16.0
 
 jobs:
+  # Gating lives here, at job level, not in a `paths:` filter on the trigger.
+  # A workflow that a trigger-level `paths:` filtered out reports no status at
+  # all, which leaves a required status check pending forever and blocks the
+  # PR. This job always runs, always reports, and costs seconds; the expensive
+  # lanes below read its output. Same pattern as `run_tests.yml::orchestrate`.
+  changes:
+    name: Detect libghostty inputs
+    runs-on: ubuntu-latest
+    outputs:
+      native: ${{ steps.filter.outputs.native }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        id: filter
+        with:
+          filters: |
+            native:
+              - '.github/actions/linux-build-deps/action.yml'
+              - '.github/workflows/libghostty-linux.yml'
+              - '.github/workflows/release.yml'
+              - 'Cargo.lock'
+              - 'Cargo.toml'
+              - 'assets/icons/**'
+              - 'assets/io.github.arthurdev44.paneflow.metainfo.xml'
+              - 'assets/paneflow.desktop'
+              - 'crates/paneflow-ghostty-smoke/**'
+              - 'crates/paneflow-libghostty-sys/**'
+              - 'crates/paneflow-terminal-ghostty/**'
+              - 'debian/changelog'
+              - 'deny.toml'
+              - 'fuzz/**'
+              - 'native/libghostty/**'
+              - 'packaging/AppRun'
+              - 'packaging/debian/**'
+              - 'packaging/paneflow-release.asc'
+              - 'packaging/rpm/**'
+              - 'scripts/*libghostty*'
+              - 'scripts/bundle-appimage.sh'
+              - 'scripts/bundle-tarball.sh'
+              - 'src-app/Cargo.toml'
+              - 'src-app/src/terminal/**'
+              - 'src-app/tests/dependency_source_policy.rs'
+
   native:
     name: Native, tests, release, package (${{ matrix.arch }})
+    needs: changes
+    if: >-
+      needs.changes.outputs.native == 'true' ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -106,8 +95,14 @@ jobs:
             target: aarch64-unknown-linux-gnu
             runs-on: ubuntu-22.04-arm
     runs-on: ${{ matrix.runs-on }}
+    # Two clean Ghostty builds (--verify-reproducible), the workspace test
+    # run, a release build and four package formats. This was the only long
+    # job in the four workflows with no backstop but the 360 min default.
+    timeout-minutes: 150
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Checkout pinned Ghostty source
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -116,6 +111,27 @@ jobs:
           ref: ${{ env.GHOSTTY_SHA }}
           path: .ghostty-source
           fetch-depth: 1
+          persist-credentials: false
+
+      # `GHOSTTY_SHA` / `ZIG_VERSION` are duplicated in three workflows on top
+      # of native/libghostty/manifest.toml. Keep them visible in `env:` (the
+      # Ghostty checkout above needs the value before any script can run) but
+      # fail loudly the moment a manifest bump forgets one of the copies.
+      - name: Verify workflow pins match the manifest
+        run: |
+          manifest_string() {
+            sed -n "s/^$1 = \"\(.*\)\"$/\1/p" native/libghostty/manifest.toml
+          }
+          for key in source_sha:"$GHOSTTY_SHA" zig_version:"$ZIG_VERSION"; do
+            name="${key%%:*}"
+            want="${key#*:}"
+            got="$(manifest_string "$name")"
+            if [ "$got" != "$want" ]; then
+              echo "::error::workflow pin $name is '$want' but the manifest says '$got'"
+              exit 1
+            fi
+          done
+          echo "workflow pins match native/libghostty/manifest.toml"
 
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
@@ -132,28 +148,15 @@ jobs:
           prefix-key: v1-libghostty
           key: ${{ matrix.target }}
 
-      - name: Install Linux build and packaging tools
+      - uses: ./.github/actions/linux-build-deps
+        with:
+          extra-packages: >-
+            appstream binutils elfutils icnsutils imagemagick patchelf rpm
+
+      # `Swatinem/rust-cache` above restores ${CARGO_HOME}/bin, so on a warm
+      # cache these two resolve to a no-op instead of a ~4 min rebuild.
+      - name: Install pinned packaging tools
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            appstream \
-            binutils \
-            elfutils \
-            icnsutils \
-            imagemagick \
-            libfontconfig1-dev \
-            libfreetype6-dev \
-            libvulkan-dev \
-            libwayland-dev \
-            libx11-dev \
-            libxcb-render0-dev \
-            libxcb-shape0-dev \
-            libxcb-xfixes0-dev \
-            libxcb1-dev \
-            libxkbcommon-dev \
-            libxkbcommon-x11-dev \
-            patchelf \
-            rpm
           cargo install cargo-deb --version 3.6.3 --locked
           cargo install cargo-generate-rpm --version 0.20.0 --locked
 
@@ -173,6 +176,29 @@ jobs:
              "target/libghostty/${{ matrix.target }}/"
           echo "PANEFLOW_LIBGHOSTTY_DIR=${{ github.workspace }}/target/libghostty/${{ matrix.target }}" \
             >> "$GITHUB_ENV"
+
+      # `--verify-reproducible` above only proves build-1 == build-2, and the
+      # script now also pins the result to `manifest.archive_sha256`. This step
+      # closes the last link: it proves the archive committed under
+      # native/libghostty/prebuilt - the one every release actually links,
+      # because run_tests.yml and release.yml leave PANEFLOW_LIBGHOSTTY_DIR
+      # unset - is byte-identical to what the recipe produces. Mirrors
+      # `libghostty-macos.yml::Compare against the committed prebuilt archive`.
+      - name: Compare against the committed prebuilt archive
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          rebuilt="target/libghostty/$TARGET/lib/libghostty-vt.a"
+          committed="native/libghostty/prebuilt/$TARGET/lib/libghostty-vt.a"
+          for path in "$rebuilt" "$committed"; do
+            [ -f "$path" ] || { echo "::error::missing archive $path"; exit 1; }
+          done
+          if ! cmp "$rebuilt" "$committed"; then
+            echo "::error::the committed $TARGET archive is not the one scripts/build-libghostty-linux.sh produces"
+            sha256sum "$rebuilt" "$committed"
+            exit 1
+          fi
+          sha256sum "$committed"
 
       - name: Debug tests with native backend
         run: >-
@@ -226,6 +252,7 @@ jobs:
           ARCH: ${{ matrix.arch }}
         run: |
           version="$(awk -F'"' '/^version = / { print $2; exit }' Cargo.toml)"
+          [ -n "$version" ] || { echo "::error::could not read version from Cargo.toml"; exit 1; }
           scripts/bundle-tarball.sh "$version"
           cargo deb --no-build -p paneflow-app --target "$TARGET"
           cargo generate-rpm -p src-app --target "$TARGET"
@@ -269,9 +296,16 @@ jobs:
 
   bindings:
     name: Regenerated bindings and ABI
+    needs: changes
+    if: >-
+      needs.changes.outputs.native == 'true' ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
       - name: Checkout pinned Ghostty source
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -279,12 +313,37 @@ jobs:
           ref: ${{ env.GHOSTTY_SHA }}
           path: .ghostty-source
           fetch-depth: 1
+          persist-credentials: false
+      # `GHOSTTY_SHA` / `ZIG_VERSION` are duplicated in three workflows on top
+      # of native/libghostty/manifest.toml. Keep them visible in `env:` (the
+      # Ghostty checkout above needs the value before any script can run) but
+      # fail loudly the moment a manifest bump forgets one of the copies.
+      - name: Verify workflow pins match the manifest
+        run: |
+          manifest_string() {
+            sed -n "s/^$1 = \"\(.*\)\"$/\1/p" native/libghostty/manifest.toml
+          }
+          for key in source_sha:"$GHOSTTY_SHA" zig_version:"$ZIG_VERSION"; do
+            name="${key%%:*}"
+            want="${key#*:}"
+            got="$(manifest_string "$name")"
+            if [ "$got" != "$want" ]; then
+              echo "::error::workflow pin $name is '$want' but the manifest says '$got'"
+              exit 1
+            fi
+          done
+          echo "workflow pins match native/libghostty/manifest.toml"
+
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: ${{ env.ZIG_VERSION }}
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
         with:
           toolchain: "1.96.1"
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        with:
+          prefix-key: v1-libghostty
+          key: bindings
       - name: Install pinned bindgen and native tools
         run: |
           sudo apt-get update
@@ -313,9 +372,15 @@ jobs:
         target: [parser, snapshot]
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
         with:
           toolchain: nightly-2026-07-14
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        with:
+          prefix-key: v1-libghostty
+          key: fuzz-nightly-2026-07-14
       - name: Install pinned cargo-fuzz
         run: cargo install cargo-fuzz --version 0.12.0 --locked
       - name: Download prepared x86_64 archive
@@ -331,24 +396,32 @@ jobs:
         run: cargo fuzz run "${{ matrix.target }}" -- -max_total_time="$FUZZ_SECONDS"
 
   distro-smoke:
-    name: Package smoke (${{ matrix.distro }})
+    name: Package smoke (${{ matrix.distro }}, ${{ matrix.arch }})
     needs: native
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runs-on }}
     container: ${{ matrix.image }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - distro: ubuntu
+            arch: x86_64
+            runs-on: ubuntu-22.04
             image: ubuntu:22.04@sha256:0e0a0fc6d18feda9db1590da249ac93e8d5abfea8f4c3c0c849ce512b5ef8982
             format: deb
           - distro: debian
+            arch: x86_64
+            runs-on: ubuntu-22.04
             image: debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818
             format: deb
           - distro: fedora
+            arch: x86_64
+            runs-on: ubuntu-22.04
             image: registry.fedoraproject.org/fedora:44@sha256:e70db1fd517c7d6990715fb200b1aae95ef6a1ef1492dc12c8ca25cc129a5094
             format: rpm
           - distro: opensuse
+            arch: x86_64
+            runs-on: ubuntu-22.04
             # Tag rather than digest, unlike every other leg: Tumbleweed rolls
             # daily and its registry drops the superseded manifests, so a pin
             # turns this job red with "manifest unknown" within weeks. The smoke
@@ -356,13 +429,31 @@ jobs:
             image: registry.opensuse.org/opensuse/tumbleweed:latest
             format: rpm
           - distro: arch
+            arch: x86_64
+            runs-on: ubuntu-22.04
             image: archlinux:base@sha256:fe6972d4dc1f660c0c10f4c41b2de8986bab89e7e2955378f8beadb8ebcd7433
             format: tar
+          # The `native` job builds and uploads aarch64 .deb / .rpm / tarball /
+          # AppImage on every run, and until now nothing ever installed them.
+          # One leg per package format on a native ARM runner covers the
+          # shipping aarch64 artifacts without doubling the whole matrix.
+          - distro: debian
+            arch: aarch64
+            runs-on: ubuntu-22.04-arm
+            image: debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818
+            format: deb
+          - distro: fedora
+            arch: aarch64
+            runs-on: ubuntu-22.04-arm
+            image: registry.fedoraproject.org/fedora:44@sha256:e70db1fd517c7d6990715fb200b1aae95ef6a1ef1492dc12c8ca25cc129a5094
+            format: rpm
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: libghostty-packages-x86_64
+          name: libghostty-packages-${{ matrix.arch }}
           path: candidate
       - name: Install candidate and inspection tools
         env:
@@ -431,29 +522,59 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
         with:
           toolchain: "1.96.1"
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        with:
+          prefix-key: v1-libghostty
+          key: supply-chain
       - name: Install pinned cargo-deny
         run: cargo install cargo-deny --version 0.19.8 --locked
+      # Same three checks as `run_tests.yml::security_audit`, and the same
+      # three AGENTS.md documents. A bare `cargo deny check` also ran `bans`,
+      # whose defaults apply silently because deny.toml has no [bans] section,
+      # so the two workflows could disagree about the same lockfile.
       - name: Audit Cargo graph
-        run: cargo deny check
+        run: cargo deny check advisories licenses sources
 
   validation-summary:
     name: libghostty validation
     if: always()
-    needs: [native, bindings, fuzz, distro-smoke, supply-chain]
+    needs: [changes, native, bindings, fuzz, distro-smoke, supply-chain]
     runs-on: ubuntu-22.04
     steps:
       - name: Require every automated check
         env:
+          # Fail-closed in both directions: when a libghostty input changed,
+          # every lane must be green; when none did, every lane must have
+          # actually skipped. `skipped` is never silently accepted, so a lane
+          # dropped because `native` failed still turns this job red.
+          EXPECTED_TO_RUN: ${{ needs.changes.outputs.native == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
           NATIVE: ${{ needs.native.result }}
           BINDINGS: ${{ needs.bindings.result }}
           FUZZ: ${{ needs.fuzz.result }}
           DISTRO: ${{ needs.distro-smoke.result }}
           SUPPLY: ${{ needs.supply-chain.result }}
         run: |
-          for result in "$NATIVE" "$BINDINGS" "$FUZZ" "$DISTRO" "$SUPPLY"; do
-            [ "$result" = success ] || exit 1
+          if [ "$EXPECTED_TO_RUN" = true ]; then
+            want=success
+            note="All automated libghostty Linux checks passed."
+          else
+            want=skipped
+            note="No libghostty input changed; every lane correctly skipped."
+          fi
+          status=0
+          for lane in "native:$NATIVE" "bindings:$BINDINGS" "fuzz:$FUZZ" \
+                      "distro-smoke:$DISTRO" "supply-chain:$SUPPLY"; do
+            name="${lane%%:*}"
+            result="${lane#*:}"
+            if [ "$result" != "$want" ]; then
+              echo "::error::$name reported '$result', expected '$want'"
+              status=1
+            fi
           done
-          echo "All automated libghostty Linux checks passed."
+          [ "$status" -eq 0 ] || exit 1
+          echo "$note"

--- a/.github/workflows/libghostty-macos.yml
+++ b/.github/workflows/libghostty-macos.yml
@@ -3,34 +3,8 @@ name: libghostty macOS
 on:
   push:
     branches: [main]
-    paths:
-      - ".github/workflows/libghostty-macos.yml"
-      - ".github/workflows/release.yml"
-      - ".github/workflows/run_tests.yml"
-      - "Cargo.lock"
-      - "Cargo.toml"
-      - "crates/paneflow-ghostty-smoke/**"
-      - "crates/paneflow-libghostty-sys/**"
-      - "crates/paneflow-terminal-ghostty/**"
-      - "native/libghostty/**"
-      - "scripts/*libghostty*"
-      - "src-app/Cargo.toml"
-      - "src-app/src/terminal/**"
   pull_request:
     branches: [main]
-    paths:
-      - ".github/workflows/libghostty-macos.yml"
-      - ".github/workflows/release.yml"
-      - ".github/workflows/run_tests.yml"
-      - "Cargo.lock"
-      - "Cargo.toml"
-      - "crates/paneflow-ghostty-smoke/**"
-      - "crates/paneflow-libghostty-sys/**"
-      - "crates/paneflow-terminal-ghostty/**"
-      - "native/libghostty/**"
-      - "scripts/*libghostty*"
-      - "src-app/Cargo.toml"
-      - "src-app/src/terminal/**"
   schedule:
     - cron: "7 3 * * *"
   workflow_dispatch: {}
@@ -49,6 +23,39 @@ env:
   TARGET: aarch64-apple-darwin
 
 jobs:
+  # Gating lives here, at job level, not in a `paths:` filter on the trigger.
+  # A workflow that a trigger-level `paths:` filtered out reports no status at
+  # all, which leaves a required status check pending forever and blocks the
+  # PR. This job always runs, always reports, and costs seconds; the expensive
+  # lanes below read its output. Same pattern as `run_tests.yml::orchestrate`.
+  changes:
+    name: Detect libghostty inputs
+    runs-on: ubuntu-latest
+    outputs:
+      native: ${{ steps.filter.outputs.native }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        id: filter
+        with:
+          filters: |
+            native:
+              - '.github/workflows/libghostty-macos.yml'
+              - '.github/workflows/release.yml'
+              - '.github/workflows/run_tests.yml'
+              - 'Cargo.lock'
+              - 'Cargo.toml'
+              - 'crates/paneflow-ghostty-smoke/**'
+              - 'crates/paneflow-libghostty-sys/**'
+              - 'crates/paneflow-terminal-ghostty/**'
+              - 'native/libghostty/**'
+              - 'scripts/*libghostty*'
+              - 'src-app/Cargo.toml'
+              - 'src-app/src/terminal/**'
+
   # US-015 AC5: the US-004 spike selected the Linux-host cross-build, so the
   # archive is produced on `ubuntu-22.04`. Ghostty's CombineArchivesStep only
   # takes the Apple `libtool` path when the build host is Darwin; a Linux host
@@ -57,12 +64,23 @@ jobs:
   # stays documented in the manifest, but nothing here needs it.
   native-rebuild:
     name: Rebuild pinned macOS archive (Linux host)
+    # Two clean ReleaseFast builds at -j1 is a 3 h job, and it ran on every
+    # push and PR touching these paths. What a PR actually needs to know is
+    # that the committed archive is intact, which `paneflow-libghostty-sys`
+    # asserts against `manifest.archive_sha256` on every cargo invocation in
+    # `consumer-qualification`. The full reproducibility proof runs nightly
+    # and on demand, and must be run by hand before re-pinning the archive.
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-22.04
     # Two clean ReleaseFast builds at -j1, which is what the reproducibility
     # contract requires; the seed and job count are manifest-pinned.
     timeout-minutes: 180
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Checkout pinned Ghostty source
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -71,6 +89,26 @@ jobs:
           ref: ${{ env.GHOSTTY_SHA }}
           path: .ghostty-source
           fetch-depth: 1
+          persist-credentials: false
+
+      # Fail loudly when a manifest bump forgets one of the three workflow
+      # copies of these pins.
+      - name: Verify workflow pins match the manifest
+        run: |
+          set -euo pipefail
+          manifest_string() {
+            sed -n "s/^$1 = \"\(.*\)\"$/\1/p" native/libghostty/manifest.toml
+          }
+          for key in source_sha:"$GHOSTTY_SHA" zig_version:"$ZIG_VERSION"; do
+            name="${key%%:*}"
+            want="${key#*:}"
+            got="$(manifest_string "$name")"
+            if [ "$got" != "$want" ]; then
+              echo "::error::workflow pin $name is '$want' but the manifest says '$got'"
+              exit 1
+            fi
+          done
+          echo "workflow pins match native/libghostty/manifest.toml"
 
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
@@ -124,16 +162,22 @@ jobs:
           retention-days: 14
 
   consumer-qualification:
+    needs: changes
+    if: >-
+      needs.changes.outputs.native == 'true' ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch'
     name: Repository consumer and release budget
     runs-on: macos-14
-    timeout-minutes: 180
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
         with:
           toolchain: "1.96.1"
-          components: clippy
           targets: aarch64-apple-darwin
 
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
@@ -147,16 +191,13 @@ jobs:
       # links. Never export it as an empty string here; the build script reads
       # it with `env::var_os`, so `Some("")` would resolve the artifact root to
       # the empty path and fail on `symlink_metadata`.
-      - name: Lint against the repository artifact
-        run: >-
-          cargo clippy --workspace --locked
-          --target "$TARGET" -- -D warnings
-
-      - name: Test against the repository artifact
-        run: >-
-          cargo test --workspace --locked
-          --target "$TARGET"
-
+      #
+      # clippy and `cargo test` used to run here too. They are exactly what
+      # `run_tests.yml::macos_check` already runs on macos-14 against the same
+      # committed archive, and its `libghostty` path filter covers every path
+      # that triggers this workflow, so the copy was a second 14x runner for
+      # the same answer. What is left below is what only this lane does: the
+      # end-to-end PTY smoke and the static-link / notices contract.
       - name: Build the Ghostty release candidate
         run: |
           cargo build --release --locked \
@@ -202,15 +243,42 @@ jobs:
   validation-summary:
     name: libghostty macOS validation
     if: always()
-    needs: [native-rebuild, consumer-qualification]
+    needs: [changes, native-rebuild, consumer-qualification]
     runs-on: ubuntu-22.04
     steps:
       - name: Require native and consumer lanes
         env:
+          EXPECTED_TO_RUN: ${{ needs.changes.outputs.native == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
           NATIVE: ${{ needs.native-rebuild.result }}
           CONSUMER: ${{ needs.consumer-qualification.result }}
         run: |
-          for result in "$NATIVE" "$CONSUMER"; do
-            [ "$result" = success ] || exit 1
+          # `native-rebuild` is schedule/dispatch-only, so on a push or a PR it
+          # must report `skipped`, and on a scheduled or dispatched run it must
+          # report `success`. The consumer lane must be green whenever a
+          # libghostty input changed and skipped when none did. `skipped` is
+          # never silently accepted for a lane that was supposed to run.
+          case "$GITHUB_EVENT_NAME" in
+            schedule|workflow_dispatch) want_native=success ;;
+            *) want_native=skipped ;;
+          esac
+          if [ "$EXPECTED_TO_RUN" = true ]; then
+            want_consumer=success
+            note="All automated libghostty macOS checks passed."
+          else
+            want_consumer=skipped
+            note="No libghostty input changed; the consumer lane correctly skipped."
+          fi
+          status=0
+          for lane in "native-rebuild:$NATIVE:$want_native" \
+                      "consumer-qualification:$CONSUMER:$want_consumer"; do
+            name="${lane%%:*}"
+            rest="${lane#*:}"
+            result="${rest%%:*}"
+            want="${rest#*:}"
+            if [ "$result" != "$want" ]; then
+              echo "::error::$name reported '$result', expected '$want'"
+              status=1
+            fi
           done
-          echo "All automated libghostty macOS checks passed."
+          [ "$status" -eq 0 ] || exit 1
+          echo "$note"

--- a/.github/workflows/libghostty-windows.yml
+++ b/.github/workflows/libghostty-windows.yml
@@ -3,38 +3,8 @@ name: libghostty Windows
 on:
   push:
     branches: [main]
-    paths:
-      - ".github/workflows/libghostty-windows.yml"
-      - ".github/workflows/release.yml"
-      - ".github/workflows/run_tests.yml"
-      - "Cargo.lock"
-      - "Cargo.toml"
-      - "crates/paneflow-ghostty-smoke/**"
-      - "crates/paneflow-libghostty-sys/**"
-      - "crates/paneflow-terminal-ghostty/**"
-      - "native/libghostty/**"
-      - "packaging/wix/**"
-      - "scripts/*libghostty*"
-      - "src-app/Cargo.toml"
-      - "src-app/src/**"
-      - "src-app/tests/**"
   pull_request:
     branches: [main]
-    paths:
-      - ".github/workflows/libghostty-windows.yml"
-      - ".github/workflows/release.yml"
-      - ".github/workflows/run_tests.yml"
-      - "Cargo.lock"
-      - "Cargo.toml"
-      - "crates/paneflow-ghostty-smoke/**"
-      - "crates/paneflow-libghostty-sys/**"
-      - "crates/paneflow-terminal-ghostty/**"
-      - "native/libghostty/**"
-      - "packaging/wix/**"
-      - "scripts/*libghostty*"
-      - "src-app/Cargo.toml"
-      - "src-app/src/**"
-      - "src-app/tests/**"
   schedule:
     - cron: "41 2 * * *"
   workflow_dispatch: {}
@@ -54,8 +24,47 @@ env:
   NATIVE_PROFILE: ReleaseFast-simd-fixedbase-seed0-j1
 
 jobs:
+  # Gating lives here, at job level, not in a `paths:` filter on the trigger.
+  # A workflow that a trigger-level `paths:` filtered out reports no status at
+  # all, which leaves a required status check pending forever and blocks the
+  # PR. This job always runs, always reports, and costs seconds; the expensive
+  # lanes below read its output. Same pattern as `run_tests.yml::orchestrate`.
+  changes:
+    name: Detect libghostty inputs
+    runs-on: ubuntu-latest
+    outputs:
+      native: ${{ steps.filter.outputs.native }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        id: filter
+        with:
+          filters: |
+            native:
+              - '.github/workflows/libghostty-windows.yml'
+              - '.github/workflows/release.yml'
+              - '.github/workflows/run_tests.yml'
+              - 'Cargo.lock'
+              - 'Cargo.toml'
+              - 'crates/paneflow-ghostty-smoke/**'
+              - 'crates/paneflow-libghostty-sys/**'
+              - 'crates/paneflow-terminal-ghostty/**'
+              - 'native/libghostty/**'
+              - 'packaging/wix/**'
+              - 'scripts/*libghostty*'
+              - 'src-app/Cargo.toml'
+              - 'src-app/src/terminal/**'
+
   native-rebuild:
     name: Rebuild pinned native archive
+    needs: changes
+    if: >-
+      needs.changes.outputs.native == 'true' ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch'
     runs-on: windows-2022
     timeout-minutes: 90
     defaults:
@@ -63,6 +72,8 @@ jobs:
         shell: pwsh
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Checkout pinned Ghostty source
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -71,6 +82,22 @@ jobs:
           ref: ${{ env.GHOSTTY_SHA }}
           path: .ghostty-source
           fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify workflow pins match the manifest
+        run: |
+          $ManifestPath = Join-Path $PWD 'native\libghostty\manifest.toml'
+          . (Join-Path $PWD 'scripts\libghostty-manifest.ps1')
+          foreach ($pin in @(
+            @{ Key = 'source_sha'; Value = $env:GHOSTTY_SHA },
+            @{ Key = 'zig_version'; Value = $env:ZIG_VERSION }
+          )) {
+            $actual = Get-ManifestString $pin.Key
+            if ($actual -ne $pin.Value) {
+              throw "workflow pin $($pin.Key) is '$($pin.Value)' but the manifest says '$actual'"
+            }
+          }
+          Write-Host 'workflow pins match native/libghostty/manifest.toml'
 
       - name: Install manifest-pinned Zig distribution
         run: |
@@ -100,6 +127,7 @@ jobs:
         env:
           MSVC_COMPONENT: Microsoft.VisualStudio.Component.VC.14.38.17.8.x86.x64
           WINDOWS_SDK_COMPONENT: Microsoft.VisualStudio.Component.Windows11SDK.26100
+          LLVM_COMPONENT: Microsoft.VisualStudio.Component.VC.Llvm.Clang
         run: |
           $installerRoot = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer'
           $vswhere = Join-Path $installerRoot 'vswhere.exe'
@@ -109,7 +137,7 @@ jobs:
             throw 'Visual Studio 2022 is not installed on the runner.'
           }
 
-          $requiredComponents = @($env:MSVC_COMPONENT, $env:WINDOWS_SDK_COMPONENT)
+          $requiredComponents = @($env:MSVC_COMPONENT, $env:WINDOWS_SDK_COMPONENT, $env:LLVM_COMPONENT)
           $missingComponents = @(
             foreach ($component in $requiredComponents) {
               $installedAt = (& $vswhere -latest -products * -requires $component -property installationPath | Select-Object -First 1)
@@ -149,6 +177,23 @@ jobs:
           if (-not (Test-Path -LiteralPath $sdkPath -PathType Container)) {
             throw "The manifest-pinned Windows SDK was not found at $sdkPath."
           }
+
+          # The archive normalization recipe is LLVM-version-sensitive, and the
+          # build script hard-fails on any other version. Surface that as a
+          # labelled preflight failure rather than an opaque llvm-objcopy error
+          # 40 minutes into the rebuild.
+          $ManifestPath = Join-Path $PWD 'native\libghostty\manifest.toml'
+          . (Join-Path $PWD 'scripts\libghostty-manifest.ps1')
+          $expectedLlvm = Get-ManifestString 'windows_llvm_version'
+          $llvmObjcopy = Join-Path $installationPath 'VC\Tools\Llvm\x64\bin\llvm-objcopy.exe'
+          if (-not (Test-Path -LiteralPath $llvmObjcopy -PathType Leaf)) {
+            throw "The LLVM normalization tools were not found at $llvmObjcopy."
+          }
+          $llvmVersion = @(& $llvmObjcopy --version)
+          if ($LASTEXITCODE -ne 0 -or -not ($llvmVersion -match "LLVM version $([regex]::Escape($expectedLlvm))")) {
+            throw "libghostty requires LLVM normalization tools $expectedLlvm; this runner carries: $($llvmVersion -join ' ')"
+          }
+          Write-Host "LLVM normalization tools: $expectedLlvm at $llvmObjcopy"
 
       # The rebuild deliberately has no native object cache. The canonical
       # source/cache paths are part of the reproducibility contract, and the
@@ -213,18 +258,27 @@ jobs:
           retention-days: 30
 
   consumer-qualification:
+    needs: changes
+    if: >-
+      needs.changes.outputs.native == 'true' ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch'
     name: Repository consumer and release budgets
     # Windows Server 2022 build 20348 carries microsoft/terminal#8706:
     # ClosePseudoConsole leaks its internal OpenConsole process handle once per
     # session. Run resource gates on the build-26100 ConPTY line so they measure
     # Paneflow ownership; supported Windows 10/11 remain in the manual matrix.
     runs-on: windows-2025
-    timeout-minutes: 120
+    # Was 120 for fmt + clippy --all-targets + test + qualification. Only the
+    # qualification build is left.
+    timeout-minutes: 60
     defaults:
       run:
         shell: pwsh
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Setup MSVC developer environment
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
@@ -234,7 +288,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
         with:
           toolchain: "1.96.1"
-          components: rustfmt, clippy
           targets: x86_64-pc-windows-msvc
 
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
@@ -242,15 +295,12 @@ jobs:
           prefix-key: v1-libghostty-windows-consumer
           key: ${{ env.TARGET }}-${{ env.GHOSTTY_SHA }}-${{ env.ZIG_VERSION }}-${{ env.NATIVE_PROFILE }}-${{ hashFiles('Cargo.lock', 'native/libghostty/manifest.toml') }}
 
-      - name: Check workspace formatting
-        run: cargo fmt --all --check
-
-      - name: Lint all Windows targets against the repository artifact
-        run: cargo clippy --workspace --all-targets --locked --target $env:TARGET -- -D warnings
-
-      - name: Test the Windows workspace against the repository artifact
-        run: cargo test --workspace --locked --target $env:TARGET
-
+      # fmt, clippy --all-targets and `cargo test` used to run here. They are
+      # what `run_tests.yml::windows_check` runs on every commit against the
+      # same committed archive, and it now passes `--all-targets` too, so this
+      # was a second Windows runner producing the same answer. What is left is
+      # the part only this lane can do: qualification on the build-26100
+      # ConPTY line.
       - name: Qualify repository artifact on the controlled runner
         env:
           QUALIFICATION_DIR: ${{ runner.temp }}\libghostty-windows-qualification
@@ -270,14 +320,33 @@ jobs:
   validation-summary:
     name: libghostty Windows validation
     if: always()
-    needs: [native-rebuild, consumer-qualification]
+    needs: [changes, native-rebuild, consumer-qualification]
     runs-on: ubuntu-22.04
     steps:
       - name: Require native and consumer lanes
         env:
+          # Fail-closed in both directions: when a libghostty input changed,
+          # both lanes must be green; when none did, both must have actually
+          # skipped. `skipped` is never silently accepted.
+          EXPECTED_TO_RUN: ${{ needs.changes.outputs.native == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
           NATIVE: ${{ needs.native-rebuild.result }}
           CONSUMER: ${{ needs.consumer-qualification.result }}
         run: |
-          test "$NATIVE" = success
-          test "$CONSUMER" = success
-          echo "All automated libghostty Windows checks passed."
+          if [ "$EXPECTED_TO_RUN" = true ]; then
+            want=success
+            note="All automated libghostty Windows checks passed."
+          else
+            want=skipped
+            note="No libghostty input changed; both lanes correctly skipped."
+          fi
+          status=0
+          for lane in "native-rebuild:$NATIVE" "consumer-qualification:$CONSUMER"; do
+            name="${lane%%:*}"
+            result="${lane#*:}"
+            if [ "$result" != "$want" ]; then
+              echo "::error::$name reported '$result', expected '$want'"
+              status=1
+            fi
+          done
+          [ "$status" -eq 0 ] || exit 1
+          echo "$note"

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -44,14 +44,6 @@ jobs:
   #   - rust:             any Rust source or manifest changed
   #   - rendering:        the GPUI paint / font / theme paths the visual
   #                       smoke jobs are designed to protect
-  #   - changed_packages: space-separated cargo workspace member names
-  #                       whose source tree changed. Empty string means
-  #                       "workspace-wide change OR cannot compute" -
-  #                       downstream consumers must treat empty as
-  #                       "everything changed" (fail-safe). Computed
-  #                       dynamically via `cargo metadata --no-deps`
-  #                       so adding new workspace members requires no
-  #                       workflow update.
   #
   # Gating posture (US-018 AC5 etc.): the macos-14 / windows-2022
   # runners are 14× / 2× pricier than ubuntu-latest and contribute
@@ -71,18 +63,15 @@ jobs:
       ci: ${{ steps.filter.outputs.ci }}
       security: ${{ steps.filter.outputs.security }}
       release_packaging: ${{ steps.filter.outputs.release_packaging }}
-      changed_packages: ${{ steps.detect_packages.outputs.changed_packages }}
     steps:
-      # fetch-depth tuned for the `detect_packages` git diff below: on a
-      # PR we need enough history to reach the merge-base with the base
-      # branch (~350 commits matches Zed's pattern, comfortably covers
-      # long-running feature branches); on a push to main HEAD~1 is
-      # enough.
-      - uses: actions/checkout@v5
+      # `dorny/paths-filter` fetches the base ref it needs on its own, so a
+      # shallow checkout is enough here.
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          fetch-depth: ${{ github.event_name == 'pull_request' && 350 || 2 }}
+          persist-credentials: false
+          fetch-depth: 1
 
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
           filters: |
@@ -143,96 +132,6 @@ jobs:
               - 'src-app/src/layout/render.rs'
               - 'src-app/tests/flex_nchild.rs'
 
-      # Per-package detector. Adapted from Zed's orchestrate step. The
-      # output isn't consumed yet (`cargo test --workspace` still runs
-      # cheaply enough), but exposing it now lets
-      # future jobs gate per-crate (e.g. when crate count grows or
-      # nextest is adopted). Empty `changed_packages` means "treat as
-      # full rebuild" - fail-safe default.
-      #
-      # cargo + jq are preinstalled on ubuntu-latest. cargo metadata's
-      # output is JSON; jq extracts the member-name × directory map.
-      - id: detect_packages
-        name: Detect changed Cargo packages
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if [ -z "${GITHUB_BASE_REF:-}" ]; then
-            echo "Push event - comparing against HEAD~1"
-            COMPARE_REV="$(git rev-parse HEAD~1 2>/dev/null || true)"
-          else
-            echo "PR event - comparing against merge-base with ${GITHUB_BASE_REF}"
-            git fetch origin "$GITHUB_BASE_REF" --depth=350 || true
-            COMPARE_REV="$(git merge-base "origin/${GITHUB_BASE_REF}" HEAD 2>/dev/null || true)"
-          fi
-
-          if [ -z "$COMPARE_REV" ]; then
-            echo "Cannot determine compare base - treating as full rebuild"
-            echo "changed_packages=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          CHANGED_FILES="$(git diff --name-only "$COMPARE_REV" "$GITHUB_SHA" || true)"
-          echo "$CHANGED_FILES" | head -20
-
-          # Workspace-wide change → bypass per-package detection. Matches
-          # Zed's pattern: any edit to the toolchain pin, cargo config,
-          # root manifest/lockfile, or workflow files forces a full
-          # rebuild because the change can affect every crate.
-          if echo "$CHANGED_FILES" | grep -qE '^(rust-toolchain\.toml|\.cargo/|Cargo\.lock$|Cargo\.toml$|\.github/workflows/)'; then
-            echo "Workspace-wide change detected - emitting empty changed_packages (treat as full rebuild)"
-            echo "changed_packages=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Build dir→pkg map dynamically from cargo metadata so new
-          # workspace members are auto-detected. manifest_path looks
-          # like `/.../src-app/Cargo.toml` or
-          # `/.../crates/paneflow-config/Cargo.toml`; capture the leaf
-          # directory.
-          DIR_TO_PKG="$(cargo metadata --format-version=1 --no-deps 2>/dev/null \
-            | jq -r '
-                .packages[]
-                | select(.manifest_path | test("/(src-app|crates/[^/]+)/Cargo\\.toml$"))
-                | (.manifest_path | capture("/(?<dir>src-app|crates/[^/]+)/Cargo\\.toml$") | .dir)
-                  + "=" + .name
-              ' || true)"
-          echo "Workspace member map:"
-          echo "$DIR_TO_PKG"
-
-          if [ -z "$DIR_TO_PKG" ]; then
-            echo "cargo metadata returned no members - treating as full rebuild"
-            echo "changed_packages=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # For each member dir, check whether any file under it changed.
-          CHANGED_PKGS=""
-          while IFS='=' read -r dir pkg; do
-            [ -n "$dir" ] || continue
-            if echo "$CHANGED_FILES" | grep -qE "^${dir}/"; then
-              CHANGED_PKGS="${CHANGED_PKGS}${pkg} "
-            fi
-          done <<< "$DIR_TO_PKG"
-
-          # Empty CHANGED_PKGS means the diff touched files outside every
-          # workspace member dir (e.g. root-level deny.toml, docs/, tasks/).
-          # Treat as a no-op for per-package gating - downstream consumers
-          # interpret empty changed_packages as "full rebuild" (fail-safe).
-          # The early-return avoids piping empty input into `grep -v '^$'`,
-          # which exits 1 on no-match and trips `set -euo pipefail` because
-          # bash propagates command-substitution exit status under `set -e`.
-          if [ -z "${CHANGED_PKGS// /}" ]; then
-            echo "No workspace member touched - emitting empty changed_packages"
-            echo "changed_packages=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          CHANGED_PKGS="$(echo "$CHANGED_PKGS" | tr ' ' '\n' | grep -v '^$' | sort -u | tr '\n' ' ' | sed 's/ $//')"
-          echo "Changed packages: '${CHANGED_PKGS}'"
-          echo "changed_packages=${CHANGED_PKGS}" >> "$GITHUB_OUTPUT"
-
   # Linux quality gates are split into 3 parallel jobs so the wall-clock
   # time of the CI run is max(jobs) instead of sum(steps). Previously a
   # single `check` job ran fmt → clippy → test → release-build → size
@@ -261,30 +160,18 @@ jobs:
       needs.orchestrate.outputs.release_packaging == 'true'
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libvulkan-dev \
-            libwayland-dev \
-            libxkbcommon-dev \
-            libx11-dev \
-            libxcb1-dev \
-            libxcb-render0-dev \
-            libxcb-shape0-dev \
-            libxcb-xfixes0-dev \
-            libxkbcommon-x11-dev \
-            libfontconfig1-dev \
-            libfreetype6-dev
+      - uses: ./.github/actions/linux-build-deps
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
         with:
           toolchain: "1.96.1"
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           prefix-key: "v1-rust"
           key: check_style
@@ -293,7 +180,7 @@ jobs:
         run: cargo fmt --check
 
       - name: Clippy
-        run: cargo clippy --workspace --locked -- -D warnings
+        run: cargo clippy --workspace --all-targets --locked -- -D warnings
 
   run_tests_linux:
     name: Tests (Linux x86_64)
@@ -304,29 +191,17 @@ jobs:
       needs.orchestrate.outputs.release_packaging == 'true'
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libvulkan-dev \
-            libwayland-dev \
-            libxkbcommon-dev \
-            libx11-dev \
-            libxcb1-dev \
-            libxcb-render0-dev \
-            libxcb-shape0-dev \
-            libxcb-xfixes0-dev \
-            libxkbcommon-x11-dev \
-            libfontconfig1-dev \
-            libfreetype6-dev
+      - uses: ./.github/actions/linux-build-deps
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
         with:
           toolchain: "1.96.1"
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           prefix-key: "v1-rust"
           key: run_tests_linux
@@ -343,29 +218,17 @@ jobs:
       needs.orchestrate.outputs.release_packaging == 'true'
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libvulkan-dev \
-            libwayland-dev \
-            libxkbcommon-dev \
-            libx11-dev \
-            libxcb1-dev \
-            libxcb-render0-dev \
-            libxcb-shape0-dev \
-            libxcb-xfixes0-dev \
-            libxkbcommon-x11-dev \
-            libfontconfig1-dev \
-            libfreetype6-dev
+      - uses: ./.github/actions/linux-build-deps
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
         with:
           toolchain: "1.96.1"
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           prefix-key: "v1-rust"
           key: release_build_linux
@@ -502,28 +365,30 @@ jobs:
       needs.orchestrate.outputs.ci == 'true'
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
         with:
           toolchain: "1.96.1"
 
-      # Reuse the same cache prefix as `check` so the advisory job
-      # shares target/ with the main Linux build (no extra minutes
-      # spent re-compiling for cargo-deny's own resolve).
-      - uses: Swatinem/rust-cache@v2
+      # `rust-cache` keys on prefix-key + key + job, so this slot is this
+      # job's own; it is not shared with `check_style`. What it buys here is
+      # ${CARGO_HOME}/bin, which keeps the `cargo install cargo-deny` below
+      # off the critical path on a warm cache.
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           prefix-key: "v1-rust"
           key: security-audit
 
-      - name: Install cargo-deny (pinned 0.19.x)
-        # `--locked` pins cargo-deny's own dep graph for reproducibility.
-        # `--version '^0.19'` accepts any 0.19.x patch but not 0.20+
-        # (verified against deny.toml semantics: 0.16+ introduces the
-        # `unmaintained = "workspace"` scope and `[[licenses.exceptions]]`
-        # syntax we rely on; 0.19 is the current stable upstream and
-        # the version validated locally before bumping).
-        run: cargo install cargo-deny --locked --version '^0.19'
+      - name: Install cargo-deny
+        # Exact pin, matching `libghostty-linux.yml::supply-chain`. A floating
+        # `^0.19` let the two workflows resolve different patch releases and
+        # disagree about the same lockfile. `--locked` pins cargo-deny's own
+        # dep graph on top of that. The rust-cache step above restores
+        # ${CARGO_HOME}/bin, so this is a no-op compile on a warm cache.
+        run: cargo install cargo-deny --locked --version 0.19.8
 
       - name: cargo deny check advisories licenses sources
         # Retry once with 30s backoff on a DB-fetch failure (GitHub's
@@ -568,6 +433,7 @@ jobs:
     if: >-
       needs.orchestrate.outputs.rust == 'true' ||
       needs.orchestrate.outputs.libghostty == 'true' ||
+      needs.orchestrate.outputs.rendering == 'true' ||
       needs.orchestrate.outputs.ci == 'true' ||
       needs.orchestrate.outputs.release_packaging == 'true'
     runs-on: macos-14
@@ -577,7 +443,9 @@ jobs:
     # the PR per the US-001 AC5 note above. The timeout is the hard backstop.
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       # US-003 - fail fast if the runner image drifts away from a full Xcode
       # install. The macos-14 hosted image ships Xcode 15+ with the Metal
@@ -619,7 +487,7 @@ jobs:
           fi
           echo "Metal framework headers: $METAL_HEADERS"
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
         with:
           toolchain: "1.96.1"
           targets: aarch64-apple-darwin
@@ -628,7 +496,7 @@ jobs:
           # does NOT install by default even when `targets:` is set.
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           prefix-key: "v1-rust"
           key: aarch64-apple-darwin
@@ -648,7 +516,7 @@ jobs:
       # this is what type-checks the native modules against a Darwin target.
       - name: cargo clippy (aarch64-apple-darwin)
         run: >-
-          cargo clippy --workspace --locked
+          cargo clippy --workspace --all-targets --locked
           --target aarch64-apple-darwin -- -D warnings
 
       # cargo test on the config crate (39 tests) + app crate (testable
@@ -682,7 +550,7 @@ jobs:
       # they can `file`/`otool` locally if something downstream misbehaves.
       - name: Upload aarch64 binary artifact
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: paneflow-aarch64-apple-darwin
           path: target/aarch64-apple-darwin/release/paneflow
@@ -737,10 +605,12 @@ jobs:
     runs-on: macos-14
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Download paneflow binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: paneflow-aarch64-apple-darwin
           path: target/aarch64-apple-darwin/release/
@@ -835,7 +705,7 @@ jobs:
 
       - name: Upload visual smoke artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: macos_render_smoke
           path: |
@@ -869,6 +739,7 @@ jobs:
     needs: orchestrate
     if: >-
       needs.orchestrate.outputs.rust == 'true' ||
+      needs.orchestrate.outputs.rendering == 'true' ||
       needs.orchestrate.outputs.ci == 'true' ||
       needs.orchestrate.outputs.release_packaging == 'true'
     runs-on: windows-2022
@@ -881,28 +752,16 @@ jobs:
       run:
         shell: pwsh
     timeout-minutes: 50
-    env:
-      # US-009 (v0.2.1): `ilammy/msvc-dev-cmd@v1` (latest v1.13.0 as of
-      # 2026-04-21) still declares `runs: using: node20` in its
-      # action.yml. Upstream issue #99 + PR #101 are open but not
-      # merged. GitHub Actions force-migrates to Node 24 on 2026-06-02
-      # and removes Node 20 on 2026-09-16. This env shim instructs the
-      # runner to execute the action on the node24 binary regardless
-      # of its declared runtime - documented in
-      # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
-      # Remove this env once `ilammy/msvc-dev-cmd` publishes a tag
-      # that declares `using: node24` natively, and pin to that tag.
-      # Scoped to this job so other jobs don't silently accept
-      # stragglers elsewhere.
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       # Load VS 2022 Build Tools env: cl.exe, link.exe, lib.exe on PATH,
       # INCLUDE/LIB/LIBPATH set. Required by AC-2's `where cl.exe link.exe`.
       # x64 arch targets the same toolchain the rustc msvc triple uses.
       - name: Setup MSVC developer environment
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         with:
           arch: x64
 
@@ -937,13 +796,13 @@ jobs:
       # US-003 AC-1 + US-018 AC-1: Rust toolchain with rustfmt + clippy
       # components (required by the fmt/clippy steps below) and the MSVC
       # cross-compile target.
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
         with:
           toolchain: "1.96.1"
           components: rustfmt, clippy
           targets: x86_64-pc-windows-msvc
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           prefix-key: "v1-rust"
           key: x86_64-pc-windows-msvc
@@ -984,7 +843,7 @@ jobs:
       # matching the Linux `check` job pattern (line 74) and the release
       # pipeline's clippy gate.
       - name: cargo clippy --target x86_64-pc-windows-msvc
-        run: cargo clippy --workspace --locked --target x86_64-pc-windows-msvc -- -D warnings
+        run: cargo clippy --workspace --all-targets --locked --target x86_64-pc-windows-msvc -- -D warnings
 
       # AC-2 step 3/4: tests. Ghostty is linked unconditionally, so the
       # workspace run executes the Windows backend corpus against the real
@@ -1041,7 +900,7 @@ jobs:
       # PRs is fast, but the from-scratch path on cold runs is ~5 min).
       - name: Upload x86_64 binary artifact
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: paneflow-x86_64-pc-windows-msvc
           path: target/x86_64-pc-windows-msvc/release/paneflow.exe
@@ -1083,10 +942,12 @@ jobs:
     runs-on: windows-2022
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Download paneflow.exe
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: paneflow-x86_64-pc-windows-msvc
           path: target/x86_64-pc-windows-msvc/release/
@@ -1160,7 +1021,7 @@ jobs:
 
       - name: Upload visual smoke artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: windows_render_smoke
           path: |
@@ -1205,31 +1066,19 @@ jobs:
     # complexity is why this job prefers the native runner.
     runs-on: ubuntu-22.04-arm
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libvulkan-dev \
-            libwayland-dev \
-            libxkbcommon-dev \
-            libx11-dev \
-            libxcb1-dev \
-            libxcb-render0-dev \
-            libxcb-shape0-dev \
-            libxcb-xfixes0-dev \
-            libxkbcommon-x11-dev \
-            libfontconfig1-dev \
-            libfreetype6-dev
+      - uses: ./.github/actions/linux-build-deps
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
         with:
           toolchain: "1.96.1"
           components: rustfmt, clippy
           targets: aarch64-unknown-linux-gnu
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           prefix-key: "v1-rust"
           key: aarch64-unknown-linux-gnu
@@ -1240,7 +1089,7 @@ jobs:
         run: cargo fmt --check
 
       - name: cargo clippy (aarch64-unknown-linux-gnu)
-        run: cargo clippy --workspace --locked --target aarch64-unknown-linux-gnu -- -D warnings
+        run: cargo clippy --workspace --all-targets --locked --target aarch64-unknown-linux-gnu -- -D warnings
 
       - name: cargo test --workspace (aarch64-unknown-linux-gnu)
         run: cargo test --workspace --locked --target aarch64-unknown-linux-gnu

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Run from the repository root. The toolchain is pinned in `rust-toolchain.toml`
 
 ```bash
 cargo fmt --check                                   # mandatory before commit and push
-cargo clippy --workspace --locked -- -D warnings
+cargo clippy --workspace --all-targets --locked -- -D warnings
 cargo test --workspace --locked
 cargo deny check advisories licenses sources        # only when dependencies change
 ```
@@ -40,8 +40,14 @@ Local `cargo clippy --workspace --all-targets` runs on the host target, so every
 item behind `#[cfg(windows)]` is compiled out and never linted. The same holds
 for the `Style (fmt + clippy)` and `Tests (Linux x86_64)` jobs. Windows-gated
 code is first seen by the `Windows x86_64 libghostty check` job in
-`.github/workflows/run_tests.yml` and by `.github/workflows/libghostty-windows.yml`,
-both of which clippy `--target x86_64-pc-windows-msvc` with `-D warnings`.
+`.github/workflows/run_tests.yml`, which clippies
+`--target x86_64-pc-windows-msvc` with `-D warnings`.
+
+Every clippy gate in `run_tests.yml` passes `--all-targets`. Do not drop it:
+without it Cargo strips `#[cfg(test)]` before the HIR, so no `mod tests` is
+ever linted and a whole class of lint never fires anywhere in CI. That was the
+case until 2026-08-28, which is why this section used to name a job that could
+not in fact catch the trap below.
 
 The concrete trap: **when you add an item to a file that already has a
 `mod tests`, declare it before that module, whatever its `cfg`.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,17 @@ notes are available on the [GitHub Releases](https://github.com/arthjean/paneflo
 ### Added
 
 - Tabs name themselves. A tab opened from the preset picker used to sit in the
-  sidebar as a fourth "Claude Code" row; it now takes the opening words of the
-  first prompt sent to the agent running in it, so a rail of agents says what
-  each one is doing. Renaming a tab yourself turns naming off for that tab for
-  good - a name you typed is never overwritten - and "Reset name" in the tab's
-  context menu hands it back. A tab split between several agents is left alone,
-  since no single one speaks for it.
+  sidebar as a fourth "Claude Code" row; it now names itself after the work
+  going on inside it, so a rail of agents says what each one is doing. The
+  opening words of the first prompt land immediately as a placeholder, and the
+  title the agent's own CLI generates for its resume picker replaces it once
+  the CLI has written one (Claude Code today; Codex and Pi generate none and
+  keep the placeholder). No model of our own is ever called.
+
+  Renaming a tab yourself turns naming off for that tab for good - a name you
+  typed is never overwritten - and "Reset name" in the tab's context menu hands
+  it back. A tab split between several agents is left alone, since no single
+  one speaks for it.
 
 - Panes show a progress chip in their header when the running program reports
   OSC 9;4 progress: a percentage, `working`, `paused`, or `error`. The chip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ notes are available on the [GitHub Releases](https://github.com/arthjean/paneflo
 
 ### Added
 
+- Tabs name themselves. A tab opened from the preset picker used to sit in the
+  sidebar as a fourth "Claude Code" row; it now takes the opening words of the
+  first prompt sent to the agent running in it, so a rail of agents says what
+  each one is doing. Renaming a tab yourself turns naming off for that tab for
+  good - a name you typed is never overwritten - and "Reset name" in the tab's
+  context menu hands it back. A tab split between several agents is left alone,
+  since no single one speaks for it.
+
 - Panes show a progress chip in their header when the running program reports
   OSC 9;4 progress: a percentage, `working`, `paused`, or `error`. The chip
   clears when the program removes the indicator or the child exits.
@@ -25,6 +33,11 @@ notes are available on the [GitHub Releases](https://github.com/arthjean/paneflo
   Hold `Alt` while dragging for a rectangular (block) selection.
 
 ### Changed
+
+- Workspaces can no longer be renamed. A workspace is named after the folder it
+  holds, and a title free to drift from that folder left the sidebar claiming a
+  name nothing on disk answered to, with no way back. Double-clicking a folder
+  row now just selects it.
 
 - The statically linked Ghostty terminal engine is now the only terminal
   engine, on every platform including macOS Apple Silicon. It is always linked

--- a/crates/paneflow-ai-hook/src/event.rs
+++ b/crates/paneflow-ai-hook/src/event.rs
@@ -9,6 +9,15 @@ use serde_json::Value;
 
 pub(crate) const MAX_HOOK_TEXT_BYTES: usize = 4096;
 
+/// Cap on the `prompt` carried by `ai.prompt_submit`, which the app reads to
+/// name the tab after what the turn is about.
+///
+/// Much tighter than [`MAX_HOOK_TEXT_BYTES`] because a tab title is a handful
+/// of words: everything past the opening sentence is bytes crossing the socket
+/// on every single prompt for nothing. The app truncates again on its own side
+/// - this is about what the wire carries, not about trusting the length.
+pub(crate) const MAX_HOOK_PROMPT_BYTES: usize = 512;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum HookEvent {
     SessionStart,
@@ -204,7 +213,18 @@ fn compact_hook_payload(event: HookEvent, payload: &Value) -> Value {
 
     match event {
         HookEvent::SessionStart => copy_string_field(payload, &mut compact, "cwd", 2048),
-        HookEvent::UserPromptSubmit => {}
+        // The opening of the prompt, and only the opening: the app names the
+        // tab after the first thing asked of the agent, so a row reads "fix
+        // the flaky worktree test" instead of a fourth "Claude Code". Nothing
+        // else consumes it, and nothing interprets it - it is UNTRUSTED text
+        // that reaches a label, and the app sanitizes it there.
+        //
+        // Agents whose hook payload calls this field something else simply
+        // send no prompt, and their tabs keep the preset label. That is a
+        // missing nicety, not a broken session.
+        HookEvent::UserPromptSubmit => {
+            copy_string_field(payload, &mut compact, "prompt", MAX_HOOK_PROMPT_BYTES);
+        }
         HookEvent::Notification => {
             copy_string_field(payload, &mut compact, "notification_type", 128);
             copy_string_field(payload, &mut compact, "message", MAX_HOOK_TEXT_BYTES);
@@ -422,19 +442,60 @@ mod tests {
     }
 
     #[test]
-    fn payload_compaction_drops_prompts_and_caps_text() {
+    fn payload_compaction_caps_text() {
         let payload = json!({
             "session_id": "s1",
             "prompt": "x".repeat(10_000),
             "message": "é".repeat(10_000),
             "notification_type": "permission_prompt",
         });
-        let prompt = compact_hook_payload(HookEvent::UserPromptSubmit, &payload);
-        assert_eq!(prompt, json!({"session_id": "s1"}));
+        let submit = compact_hook_payload(HookEvent::UserPromptSubmit, &payload);
+        let prompt = submit["prompt"].as_str().expect("prompt string");
+        assert_eq!(prompt.len(), MAX_HOOK_PROMPT_BYTES);
+        assert_eq!(submit["session_id"], json!("s1"));
 
         let notification = compact_hook_payload(HookEvent::Notification, &payload);
         let message = notification["message"].as_str().expect("message string");
         assert!(message.len() <= MAX_HOOK_TEXT_BYTES);
         assert!(message.is_char_boundary(message.len()));
+    }
+
+    /// A prompt is cut on a character boundary, not a byte one - the frame
+    /// would otherwise carry a half-encoded character.
+    #[test]
+    fn a_multibyte_prompt_is_truncated_on_a_character_boundary() {
+        let payload = json!({ "prompt": "é".repeat(1_000) });
+        let submit = compact_hook_payload(HookEvent::UserPromptSubmit, &payload);
+        let prompt = submit["prompt"].as_str().expect("prompt string");
+        assert!(prompt.len() <= MAX_HOOK_PROMPT_BYTES);
+        assert!(prompt.is_char_boundary(prompt.len()));
+        assert!(
+            prompt
+                .trim_end_matches("...[truncated]")
+                .chars()
+                .all(|ch| ch == 'é'),
+            "only the shared truncation marker follows the kept text"
+        );
+    }
+
+    /// Nothing else rides along: an agent that puts its whole conversation in
+    /// the prompt payload must not push it all across the socket.
+    #[test]
+    fn payload_compaction_keeps_only_the_prompt_and_its_identifiers() {
+        let payload = json!({
+            "session_id": "s1",
+            "pid": 4242,
+            "prompt": "fix the flaky worktree test",
+            "cwd": "/home/user/project",
+            "transcript_path": "/home/user/.claude/projects/x.jsonl",
+        });
+        assert_eq!(
+            compact_hook_payload(HookEvent::UserPromptSubmit, &payload),
+            json!({
+                "session_id": "s1",
+                "pid": 4242,
+                "prompt": "fix the flaky worktree test",
+            })
+        );
     }
 }

--- a/crates/paneflow-ai-hook/tests/integration.rs
+++ b/crates/paneflow-ai-hook/tests/integration.rs
@@ -410,7 +410,9 @@ fn supported_events_dispatch_through_the_process_boundary() {
         let frame = server.expect_frame(case.name);
         let params = assert_envelope(&frame, &case);
         if case.name == "claude_prompt" {
-            assert!(params["hook_payload"].get("prompt").is_none());
+            // The prompt crosses the real process boundary intact: the app
+            // names the tab after it.
+            assert_eq!(params["hook_payload"]["prompt"], "hello");
         }
         if case.name == "codex_session_start" {
             assert_eq!(params["pid"], 4242);

--- a/crates/paneflow-config/src/loader_tests/session.rs
+++ b/crates/paneflow-config/src/loader_tests/session.rs
@@ -460,3 +460,95 @@ fn test_migrate_v1_is_idempotent_on_v2_shape() {
     migrate_session_v1(&mut state);
     assert_eq!(once, state);
 }
+
+/// A `session.json` written before auto-naming existed carries no provenance,
+/// and every title in it is either a name someone typed or a preset label.
+/// Reading that silence as `User` is the half that cannot destroy anything;
+/// the app's restore path hands the preset labels back to `Auto`.
+#[test]
+fn test_tab_title_source_is_absent_when_the_file_predates_it() {
+    let tab: TabSession = serde_json::from_str(r#"{"title": "sprint 3"}"#).unwrap();
+    assert_eq!(
+        tab.title_source, None,
+        "the app's restore path, not this schema, decides what silence means"
+    );
+}
+
+#[test]
+fn test_tab_title_source_reads_an_explicit_value() {
+    let auto: TabSession =
+        serde_json::from_str(r#"{"title": "wire up the parser", "title_source": "auto"}"#).unwrap();
+    assert_eq!(auto.title_source, Some(TabTitleSource::Auto));
+
+    let user: TabSession =
+        serde_json::from_str(r#"{"title": "sprint 3", "title_source": "user"}"#).unwrap();
+    assert_eq!(user.title_source, Some(TabTitleSource::User));
+}
+
+/// Same tolerance as `AppMode`: a value this build does not know must not cost
+/// the user every workspace in the file. It fails safe, onto the variant that
+/// protects a typed name.
+#[test]
+fn test_unknown_tab_title_source_falls_back_to_user() {
+    let tab: TabSession =
+        serde_json::from_str(r#"{"title": "sprint 3", "title_source": "summarizer"}"#).unwrap();
+    assert_eq!(tab.title_source, Some(TabTitleSource::User));
+}
+
+/// A tab Paneflow builds around a layout states its provenance outright. The
+/// paneless `empty()` is `Default`, and its blank title makes the distinction
+/// moot - a blank legacy title restores as `Auto` too.
+#[test]
+fn test_a_tab_built_in_process_is_auto() {
+    assert_eq!(
+        TabSession::with_layout(LayoutNode::Pane {
+            surfaces: vec![make_surface("/home/user/project")],
+        })
+        .title_source,
+        Some(TabTitleSource::Auto)
+    );
+    assert_eq!(TabSession::empty().title, "");
+}
+
+#[test]
+fn test_tab_title_source_survives_a_roundtrip() {
+    let state = SessionState {
+        version: SESSION_SCHEMA_VERSION,
+        active_workspace: 0,
+        workspaces: vec![make_workspace(
+            "main",
+            "/home/user/project",
+            vec![
+                TabSession {
+                    title: "sprint 3".to_string(),
+                    title_source: Some(TabTitleSource::User),
+                    layout: None,
+                },
+                TabSession {
+                    title: "wire up the parser".to_string(),
+                    title_source: Some(TabTitleSource::Auto),
+                    layout: None,
+                },
+            ],
+        )],
+        mode: AppMode::default(),
+        diff_scope: None,
+    };
+    let json = serde_json::to_string(&state).unwrap();
+    let back: SessionState = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, state);
+}
+
+/// A promoted tab's title is the surface's `custom_name`, and a v1 file cannot
+/// tell one the user typed from one Paneflow wrote. The migration says so
+/// rather than guessing, and the restore path judges it by content like every
+/// other legacy title.
+#[test]
+fn test_migrate_v1_states_no_provenance_for_promoted_titles() {
+    let mut state: SessionState = serde_json::from_str(V1_FIXTURE).unwrap();
+    migrate_session_v1(&mut state);
+
+    let ws = &state.workspaces[0];
+    assert_eq!(ws.tabs[0].title, "", "the inherited tree is an unnamed tab");
+    assert_eq!(ws.tabs[1].title_source, None);
+}

--- a/crates/paneflow-config/src/loader_tests/session.rs
+++ b/crates/paneflow-config/src/loader_tests/session.rs
@@ -476,13 +476,32 @@ fn test_tab_title_source_is_absent_when_the_file_predates_it() {
 
 #[test]
 fn test_tab_title_source_reads_an_explicit_value() {
-    let auto: TabSession =
-        serde_json::from_str(r#"{"title": "wire up the parser", "title_source": "auto"}"#).unwrap();
-    assert_eq!(auto.title_source, Some(TabTitleSource::Auto));
+    let prompt: TabSession =
+        serde_json::from_str(r#"{"title": "wire up the parser", "title_source": "prompt"}"#)
+            .unwrap();
+    assert_eq!(prompt.title_source, Some(TabTitleSource::Prompt));
+
+    let generated: TabSession =
+        serde_json::from_str(r#"{"title": "Parser wiring", "title_source": "generated"}"#).unwrap();
+    assert_eq!(generated.title_source, Some(TabTitleSource::Generated));
+
+    let preset: TabSession =
+        serde_json::from_str(r#"{"title": "Claude Code", "title_source": "preset"}"#).unwrap();
+    assert_eq!(preset.title_source, Some(TabTitleSource::Preset));
 
     let user: TabSession =
         serde_json::from_str(r#"{"title": "sprint 3", "title_source": "user"}"#).unwrap();
     assert_eq!(user.title_source, Some(TabTitleSource::User));
+}
+
+/// The field briefly had a two-value ladder whose non-user half was "auto".
+/// A session file from that build must not have every tab read as user-named,
+/// which would freeze them all out of auto-naming with no visible cause.
+#[test]
+fn test_the_retired_auto_value_reads_as_preset() {
+    let tab: TabSession =
+        serde_json::from_str(r#"{"title": "Claude Code", "title_source": "auto"}"#).unwrap();
+    assert_eq!(tab.title_source, Some(TabTitleSource::Preset));
 }
 
 /// Same tolerance as `AppMode`: a value this build does not know must not cost
@@ -497,15 +516,15 @@ fn test_unknown_tab_title_source_falls_back_to_user() {
 
 /// A tab Paneflow builds around a layout states its provenance outright. The
 /// paneless `empty()` is `Default`, and its blank title makes the distinction
-/// moot - a blank legacy title restores as `Auto` too.
+/// moot - a blank legacy title restores as `Preset` too.
 #[test]
-fn test_a_tab_built_in_process_is_auto() {
+fn test_a_tab_built_in_process_is_preset() {
     assert_eq!(
         TabSession::with_layout(LayoutNode::Pane {
             surfaces: vec![make_surface("/home/user/project")],
         })
         .title_source,
-        Some(TabTitleSource::Auto)
+        Some(TabTitleSource::Preset)
     );
     assert_eq!(TabSession::empty().title, "");
 }
@@ -526,7 +545,7 @@ fn test_tab_title_source_survives_a_roundtrip() {
                 },
                 TabSession {
                     title: "wire up the parser".to_string(),
-                    title_source: Some(TabTitleSource::Auto),
+                    title_source: Some(TabTitleSource::Prompt),
                     layout: None,
                 },
             ],
@@ -551,4 +570,49 @@ fn test_migrate_v1_states_no_provenance_for_promoted_titles() {
     let ws = &state.workspaces[0];
     assert_eq!(ws.tabs[0].title, "", "the inherited tree is an unnamed tab");
     assert_eq!(ws.tabs[1].title_source, None);
+}
+
+/// The precedence ladder, at the schema boundary that persists it. The app's
+/// `Tab::set_title` enforces it; this pins the ordering the file format
+/// promises, so a variant reordered here fails loudly rather than silently
+/// letting an automatic title overwrite a typed one.
+#[test]
+fn test_title_source_precedence_is_a_strict_ladder() {
+    use TabTitleSource::*;
+
+    // Each rank yields to every rank above it.
+    for (weaker, stronger) in [
+        (Preset, Prompt),
+        (Preset, Generated),
+        (Preset, User),
+        (Prompt, Generated),
+        (Prompt, User),
+        (Generated, User),
+    ] {
+        assert!(weaker.yields_to(stronger), "{weaker:?} -> {stronger:?}");
+        assert!(
+            !stronger.yields_to(weaker),
+            "{stronger:?} must not yield to {weaker:?}"
+        );
+    }
+
+    // The one-shot ranks refuse their own kind; the live ones accept it.
+    assert!(!Preset.yields_to(Preset), "a preset label is written once");
+    assert!(
+        !Prompt.yields_to(Prompt),
+        "a later prompt must not rename the tab away from the first"
+    );
+    assert!(
+        Generated.yields_to(Generated),
+        "a regenerated session title is a better one"
+    );
+    assert!(User.yields_to(User), "renaming twice means the second name");
+}
+
+#[test]
+fn test_only_the_top_two_ranks_settle_a_title() {
+    assert!(!TabTitleSource::Preset.is_settled());
+    assert!(!TabTitleSource::Prompt.is_settled());
+    assert!(TabTitleSource::Generated.is_settled());
+    assert!(TabTitleSource::User.is_settled());
 }

--- a/crates/paneflow-config/src/schema/session.rs
+++ b/crates/paneflow-config/src/schema/session.rs
@@ -109,35 +109,90 @@ fn is_zero(value: &usize) -> bool {
     *value == 0
 }
 
-/// Who put a tab's current title there.
+/// Who put a tab's current title there, and therefore what may replace it.
 ///
-/// This is the whole of the "a name I typed is mine" rule: auto-naming may
-/// replace an [`Auto`](TabTitleSource::Auto) title as often as it likes and
-/// must never touch a [`User`](TabTitleSource::User) one. Provenance, not the
-/// title's content, decides - a tab opened from the preset picker already
-/// carries a non-empty, non-human title ("Claude Code"), so "is it empty?"
-/// would refuse to name exactly the tabs worth naming.
+/// The variants are RANKED, weakest first, and a title may only be replaced by
+/// one of strictly higher rank - plus, for the top two, by another of its own
+/// kind. That single rule carries every guarantee tab naming makes:
 ///
-/// `Default` is `Auto`: a freshly built tab is app-named until a human says
-/// otherwise. A snapshot that states no provenance at all is a separate case;
-/// see [`TabSession::title_source`].
+/// - a name a human typed is never overwritten by anything automatic;
+/// - the title a CLI generates for its session replaces the placeholder, and a
+///   later, better one replaces it in turn;
+/// - the placeholder taken from the first prompt does NOT get replaced by the
+///   second prompt's, so a tab keeps naming the work it was opened for;
+/// - a preset label ("Claude Code") is the weakest of all, which is the whole
+///   point - it is what auto-naming exists to replace.
+///
+/// Rank, not content, decides. A tab opened from the preset picker already
+/// carries a non-empty, non-human title, so "is it empty?" would refuse to
+/// name exactly the tabs worth naming.
+///
+/// Ownership lives HERE, on the tab, and not on the agent session that
+/// produced it. Sessions are torn down a few seconds after each turn ends, so
+/// state kept there would reset every turn and let each new prompt rename the
+/// tab - which is the bug this ranking replaced.
 #[derive(Debug, Clone, Copy, Default, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum TabTitleSource {
-    /// Written by Paneflow: a preset label, or an auto-generated name.
-    /// Freely replaceable by another automatic name.
+    /// The label of the preset that opened the tab, or any other name
+    /// Paneflow gives a tab for want of a better one.
     #[default]
-    Auto,
+    Preset,
+    /// The opening words of the first prompt sent to the agent in this tab. A
+    /// placeholder: it lands instantly and says something, while the real
+    /// title does not exist yet.
+    Prompt,
+    /// The title the agent's own CLI generated for the session - what its
+    /// resume picker shows. The real name.
+    Generated,
     /// Typed by a human. Nothing but another human edit may replace it.
     User,
 }
 
+impl TabTitleSource {
+    /// Position in the ordering above. Only a strictly higher rank may
+    /// overwrite, so this is the whole precedence rule in one place.
+    fn rank(self) -> u8 {
+        match self {
+            Self::Preset => 0,
+            Self::Prompt => 1,
+            Self::Generated => 2,
+            Self::User => 3,
+        }
+    }
+
+    /// Whether a title of this kind may be replaced by another of the same
+    /// kind.
+    ///
+    /// True for the two that describe live intent: a CLI that regenerates its
+    /// session title has a better one, and a user renaming twice means the
+    /// second name. False for the two that are one-shot: the second prompt of
+    /// a session must not rename the tab away from what it was opened for, and
+    /// a second preset label would mean a tab being re-purposed, which does
+    /// not happen.
+    fn replaces_itself(self) -> bool {
+        matches!(self, Self::Generated | Self::User)
+    }
+
+    /// Whether a title written by `self` may be replaced by one from
+    /// `incoming`.
+    pub fn yields_to(self, incoming: Self) -> bool {
+        incoming.rank() > self.rank() || (incoming == self && incoming.replaces_itself())
+    }
+
+    /// Whether this title is final enough that no automatic naming should keep
+    /// looking for a better one. Reading a transcript to produce a title that
+    /// would be refused is work for nothing.
+    pub fn is_settled(self) -> bool {
+        matches!(self, Self::Generated | Self::User)
+    }
+}
+
 /// Deserialization is tolerant for the same reason [`AppMode`]'s is - an
 /// unreadable field must not cost the user every workspace in the file - and
-/// it fails *safe*: anything that is not exactly `"auto"` is read as `User`,
-/// because wrongly locking a tab out of auto-naming is a nuisance the user can
-/// undo from the tab menu, while wrongly unlocking one silently destroys a
-/// name they typed.
+/// it fails *safe*: anything unrecognized is read as `User`, because wrongly
+/// locking a tab out of auto-naming is a nuisance the user undoes from the tab
+/// menu, while wrongly unlocking one silently destroys a name they typed.
 impl<'de> Deserialize<'de> for TabTitleSource {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -157,7 +212,14 @@ impl<'de> Deserialize<'de> for TabTitleSource {
                 E: serde::de::Error,
             {
                 Ok(match value {
-                    "auto" => TabTitleSource::Auto,
+                    // "auto" was this field's single non-user value while the
+                    // ladder was still a pair. It meant "Paneflow wrote this",
+                    // which is `Preset` now. Without this arm it would fall
+                    // through to `User` and freeze every tab a session file
+                    // from that build carries.
+                    "preset" | "auto" => TabTitleSource::Preset,
+                    "prompt" => TabTitleSource::Prompt,
+                    "generated" => TabTitleSource::Generated,
                     _ => TabTitleSource::User,
                 })
             }
@@ -204,7 +266,7 @@ impl TabSession {
     pub fn with_layout(layout: LayoutNode) -> Self {
         Self {
             title: String::new(),
-            title_source: Some(TabTitleSource::Auto),
+            title_source: Some(TabTitleSource::Preset),
             layout: Some(layout),
         }
     }

--- a/crates/paneflow-config/src/schema/session.rs
+++ b/crates/paneflow-config/src/schema/session.rs
@@ -109,6 +109,64 @@ fn is_zero(value: &usize) -> bool {
     *value == 0
 }
 
+/// Who put a tab's current title there.
+///
+/// This is the whole of the "a name I typed is mine" rule: auto-naming may
+/// replace an [`Auto`](TabTitleSource::Auto) title as often as it likes and
+/// must never touch a [`User`](TabTitleSource::User) one. Provenance, not the
+/// title's content, decides - a tab opened from the preset picker already
+/// carries a non-empty, non-human title ("Claude Code"), so "is it empty?"
+/// would refuse to name exactly the tabs worth naming.
+///
+/// `Default` is `Auto`: a freshly built tab is app-named until a human says
+/// otherwise. A snapshot that states no provenance at all is a separate case;
+/// see [`TabSession::title_source`].
+#[derive(Debug, Clone, Copy, Default, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TabTitleSource {
+    /// Written by Paneflow: a preset label, or an auto-generated name.
+    /// Freely replaceable by another automatic name.
+    #[default]
+    Auto,
+    /// Typed by a human. Nothing but another human edit may replace it.
+    User,
+}
+
+/// Deserialization is tolerant for the same reason [`AppMode`]'s is - an
+/// unreadable field must not cost the user every workspace in the file - and
+/// it fails *safe*: anything that is not exactly `"auto"` is read as `User`,
+/// because wrongly locking a tab out of auto-naming is a nuisance the user can
+/// undo from the tab menu, while wrongly unlocking one silently destroys a
+/// name they typed.
+impl<'de> Deserialize<'de> for TabTitleSource {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct SourceVisitor;
+
+        impl serde::de::Visitor<'_> for SourceVisitor {
+            type Value = TabTitleSource;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a tab title provenance string")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<TabTitleSource, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(match value {
+                    "auto" => TabTitleSource::Auto,
+                    _ => TabTitleSource::User,
+                })
+            }
+        }
+
+        deserializer.deserialize_str(SourceVisitor)
+    }
+}
+
 /// Snapshot of one workspace tab: a title and the pane layout that tab owns
 /// (US-018). `layout: None` is an *empty* tab - a folder with no pane at all -
 /// which is only ever written by v2. The v1 `layout: null` meant the opposite
@@ -120,6 +178,17 @@ pub struct TabSession {
     /// fallback label rather than persisting one.
     #[serde(default)]
     pub title: String,
+    /// Who put [`Self::title`] there, or `None` when the file does not say.
+    ///
+    /// `Option` rather than a defaulted enum because the two cases genuinely
+    /// differ. A file written before auto-naming existed carries no such
+    /// field, and its titles are a mix of names people typed and preset
+    /// labels - the app's restore path tells them apart by content
+    /// (`restored_tab_title_source`). A file that DOES state its provenance
+    /// is believed as written, so a tab someone deliberately renamed
+    /// "Claude Code" keeps its lock instead of being guessed back open.
+    #[serde(default)]
+    pub title_source: Option<TabTitleSource>,
     /// Pane layout tree for this tab. `None` = the tab holds no pane.
     #[serde(default)]
     pub layout: Option<LayoutNode>,
@@ -135,6 +204,7 @@ impl TabSession {
     pub fn with_layout(layout: LayoutNode) -> Self {
         Self {
             title: String::new(),
+            title_source: Some(TabTitleSource::Auto),
             layout: Some(layout),
         }
     }
@@ -262,6 +332,12 @@ fn demote_panes_to_focused_surface(node: &mut LayoutNode, promoted: &mut Vec<Tab
                 let title = surface_title(&surface);
                 promoted.push(TabSession {
                     title,
+                    // A promoted title is the surface's `custom_name`, which
+                    // a v1 file cannot tell apart from a name the user typed
+                    // on that pane. Stating no provenance is the honest
+                    // answer, and lets the restore path judge it by content
+                    // like every other legacy title.
+                    title_source: None,
                     layout: Some(LayoutNode::Pane {
                         surfaces: vec![surface],
                     }),

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -104,6 +104,25 @@ the "running" row.
 On Windows, Codex uses a JSONL tee rather than file hooks; the shim handles that
 path at launch.
 
+## What a hook frame carries
+
+`paneflow-ai-hook` compacts each agent's payload before it crosses the socket,
+keeping only the fields the app reads. `ai.prompt_submit` carries the opening
+512 bytes of the `prompt` field, which is what names the tab after the work
+asked of the agent; `ai.stop` carries `summary`, `last_result`, and
+`transcript_path`. Everything else in an agent's payload is dropped at the hook
+rather than sent and ignored.
+
+An agent whose payload calls its prompt something else (Cursor's
+`beforeSubmitPrompt`, for one) sends no prompt, and its tabs keep the label of
+the preset that opened them. That is a missing nicety, not a broken session:
+nothing else depends on the field.
+
+Every one of those strings is UNTRUSTED terminal-adjacent text. The app treats
+them as data on their way to a label - never as instructions - and a prompt
+reaching a tab title goes through the same sanitizer as any CLI-written title
+(`clean_sidebar_title`), which strips control, bidi, and zero-width characters.
+
 ## Parent-death and interrupt guards (cross-platform)
 
 The shim (`paneflow-shim`) wraps each agent so two reliability gaps are closed on

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -108,9 +108,11 @@ path at launch.
 
 `paneflow-ai-hook` compacts each agent's payload before it crosses the socket,
 keeping only the fields the app reads. `ai.prompt_submit` carries the opening
-512 bytes of the `prompt` field, which is what names the tab after the work
-asked of the agent; `ai.stop` carries `summary`, `last_result`, and
-`transcript_path`. Everything else in an agent's payload is dropped at the hook
+512 bytes of the `prompt` field, which gives the tab a placeholder name;
+`ai.stop` carries `summary`, `last_result`, and `transcript_path`. The
+transcript path is also how the app finds the title the CLI generated for the
+session (Claude Code's `type:"ai-title"` record), which replaces that
+placeholder. Everything else in an agent's payload is dropped at the hook
 rather than sent and ignored.
 
 An agent whose payload calls its prompt something else (Cursor's

--- a/scripts/build-libghostty-linux.sh
+++ b/scripts/build-libghostty-linux.sh
@@ -5,6 +5,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MANIFEST="$ROOT/native/libghostty/manifest.toml"
 SOURCE_DIR="${PANEFLOW_GHOSTTY_SOURCE_DIR:-}"
 VERIFY_REPRODUCIBLE=0
+ALLOW_HASH_DRIFT=0
 TARGETS=()
 
 manifest_string() {
@@ -59,6 +60,13 @@ while (($#)); do
       ;;
     --verify-reproducible)
       VERIFY_REPRODUCIBLE=1
+      shift
+      ;;
+    --allow-hash-drift)
+      # Only for minting a new reviewed archive: it downgrades the manifest
+      # hash gate to a warning so the recipe can be re-pinned deliberately.
+      # Matches scripts/build-libghostty-macos.sh.
+      ALLOW_HASH_DRIFT=1
       shift
       ;;
     *)
@@ -211,6 +219,20 @@ build_one() {
   }
   local archive_sha
   archive_sha="$(sha256sum "$archive" | awk '{print $1}')"
+  # Close the recipe-to-manifest link, exactly as the macOS and Windows
+  # recipes do. Without it `--verify-reproducible` only proves build-1 ==
+  # build-2, so a tampered prebuilt tree could pass every Linux gate by
+  # shipping a matching tampered manifest hash.
+  local expected_archive_sha
+  expected_archive_sha="$(target_manifest_string "$rust_target" archive_sha256)"
+  if [[ "$archive_sha" != "$expected_archive_sha" ]]; then
+    if ((ALLOW_HASH_DRIFT)); then
+      echo "warning: canonical Linux archive hash differs from manifest; expected $expected_archive_sha, got $archive_sha" >&2
+    else
+      echo "canonical Linux archive hash differs from manifest; expected $expected_archive_sha, got $archive_sha" >&2
+      return 1
+    fi
+  fi
   cp "$ROOT/$BINDINGS_PATH" "$output/bindings.rs"
   {
     echo "source_sha=$SOURCE_SHA"

--- a/src-app/src/ai_types.rs
+++ b/src-app/src/ai_types.rs
@@ -162,6 +162,34 @@ pub struct AgentSession {
     /// against. `None` until a stamped frame lands (frames from a hook
     /// predating the field carry none and are always accepted).
     pub last_event_at_ms: Option<u64>,
+    /// Where this session stands in naming its tab after the work it was
+    /// given. See [`TabTitleSeed`]. In-memory only: the tab title it produces
+    /// is what gets persisted, and a restored session starts over.
+    pub tab_title_seed: TabTitleSeed,
+}
+
+/// The one-shot sequence that names a tab after the first prompt of the
+/// session running in it.
+///
+/// Three states rather than an `Option<String>` because "no prompt yet" and
+/// "already named" must not look alike: the second must stop the second and
+/// twentieth prompts of a session from renaming the tab out from under a name
+/// that already describes it.
+///
+/// The seed survives an unresolved surface. A session started outside the
+/// preset picker - an agent launched by hand in an existing shell - has no
+/// surface id on its first frame, and its binding lands a moment later; the
+/// title is applied then, still built from the FIRST prompt rather than
+/// whichever one happened to arrive after the surface showed up.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum TabTitleSeed {
+    /// No prompt has arrived yet.
+    #[default]
+    Unseeded,
+    /// The first prompt's title, waiting for a tab to put it on.
+    Pending(String),
+    /// This session has had its say. Later prompts change nothing.
+    Applied,
 }
 
 impl AgentSession {
@@ -177,6 +205,7 @@ impl AgentSession {
             proc_start: None,
             last_result: None,
             last_event_at_ms: None,
+            tab_title_seed: TabTitleSeed::default(),
         }
     }
 }

--- a/src-app/src/ai_types.rs
+++ b/src-app/src/ai_types.rs
@@ -162,34 +162,19 @@ pub struct AgentSession {
     /// against. `None` until a stamped frame lands (frames from a hook
     /// predating the field carry none and are always accepted).
     pub last_event_at_ms: Option<u64>,
-    /// Where this session stands in naming its tab after the work it was
-    /// given. See [`TabTitleSeed`]. In-memory only: the tab title it produces
-    /// is what gets persisted, and a restored session starts over.
-    pub tab_title_seed: TabTitleSeed,
-}
-
-/// The one-shot sequence that names a tab after the first prompt of the
-/// session running in it.
-///
-/// Three states rather than an `Option<String>` because "no prompt yet" and
-/// "already named" must not look alike: the second must stop the second and
-/// twentieth prompts of a session from renaming the tab out from under a name
-/// that already describes it.
-///
-/// The seed survives an unresolved surface. A session started outside the
-/// preset picker - an agent launched by hand in an existing shell - has no
-/// surface id on its first frame, and its binding lands a moment later; the
-/// title is applied then, still built from the FIRST prompt rather than
-/// whichever one happened to arrive after the surface showed up.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub enum TabTitleSeed {
-    /// No prompt has arrived yet.
-    #[default]
-    Unseeded,
-    /// The first prompt's title, waiting for a tab to put it on.
-    Pending(String),
-    /// This session has had its say. Later prompts change nothing.
-    Applied,
+    /// The placeholder title built from this session's FIRST prompt, held
+    /// only until it has been put on a tab.
+    ///
+    /// It waits here because a session's pane is not always known when its
+    /// first prompt arrives - an agent launched by hand in an existing shell
+    /// binds a moment later. Holding it means that tab is still named after
+    /// the first prompt rather than whichever one followed the binding.
+    ///
+    /// Nothing durable lives here. Sessions are torn down a few seconds after
+    /// each turn ends, so "this tab has been named" is a fact about the TAB
+    /// (`TabTitleSource`), not about the session: keeping it here let every
+    /// new turn rename the tab after its own prompt.
+    pub pending_tab_title: Option<String>,
 }
 
 impl AgentSession {
@@ -205,7 +190,7 @@ impl AgentSession {
             proc_start: None,
             last_result: None,
             last_event_at_ms: None,
-            tab_title_seed: TabTitleSeed::default(),
+            pending_tab_title: None,
         }
     }
 }

--- a/src-app/src/app/bootstrap.rs
+++ b/src-app/src/app/bootstrap.rs
@@ -752,9 +752,8 @@ impl PaneFlowApp {
         cx.observe(&workspace_pane_prompt_input, |_, _, cx| cx.notify())
             .detach();
 
-        // Issue #32: the sidebar inline rename shares one field between the
-        // workspace rows and the tab rows, mirroring the single `renaming_idx`
-        // / `renaming_tab` pair - only one rename can be live at a time.
+        // Issue #32: the sidebar inline rename is a real text field, and a
+        // single one - `renaming_tab` names the one row that can be editing.
         let rename_input = cx.new(|cx| crate::widgets::text_input::TextInput::new("", "Name", cx));
         cx.observe(&rename_input, |_, _, cx| cx.notify()).detach();
 
@@ -768,7 +767,6 @@ impl PaneFlowApp {
         let mut app = Self {
             workspaces,
             active_idx,
-            renaming_idx: None,
             renaming_tab: None,
             rename_input,
             rename_focus_live: false,

--- a/src-app/src/app/ipc_handler.rs
+++ b/src-app/src/app/ipc_handler.rs
@@ -942,7 +942,7 @@ fn workspace_surface_entries(workspaces: &[Workspace], cx: &App) -> Vec<SurfaceE
                     entries.push(surface_entry_for(
                         entity.clone(),
                         ws_idx,
-                        Some((tab.id, tab.title.clone())),
+                        Some((tab.id, tab.title().to_string())),
                         cx,
                     ));
                 }

--- a/src-app/src/app/ipc_handler.rs
+++ b/src-app/src/app/ipc_handler.rs
@@ -31,7 +31,7 @@ use crate::layout::LayoutTree;
 use crate::layout::{MAX_PANES, SplitDirection};
 use crate::pane::Pane;
 use crate::terminal::TerminalView;
-use crate::workspace::{MAX_WORKSPACES, Workspace, next_workspace_id};
+use crate::workspace::{MAX_WORKSPACES, Tab, Workspace, next_workspace_id};
 use crate::{PaneFlowApp, ai_types, keybindings, update};
 
 /// Prompt-prefill readiness window for `workspace.up` (US-010,
@@ -2301,25 +2301,26 @@ impl PaneFlowApp {
         }
     }
 
-    /// Name the tab of `session_key`'s pane after the first prompt of that
-    /// session, if it is still waiting to be named.
+    /// Put the placeholder built from a session's first prompt on the tab its
+    /// pane lives in.
     ///
     /// Called from the two places a naming can become possible: the prompt
     /// arriving, and the pane behind it being resolved. Idempotent, and cheap
-    /// enough to sit on both - a session past its one naming leaves on the
-    /// first line.
+    /// enough to sit on both.
     ///
-    /// Four things can refuse the name, and all four are ordinary rather than
-    /// error cases:
-    /// - the session has already named its tab, or has no prompt yet;
-    /// - its pane is not resolved (a late binding retries through
-    ///   `set_session_surface`, still carrying the FIRST prompt);
-    /// - the tab holds several terminals, so no single session speaks for it;
-    /// - the user has named the tab, and [`Tab::set_title`] refuses.
+    /// It lands the moment the prompt is sent, which is the point - the title
+    /// the CLI generates does not exist yet, and will replace this one a turn
+    /// or two later ([`Self::schedule_generated_title_scan`]). It is written
+    /// at [`TabTitleSource::Prompt`], which outranks a preset label and
+    /// nothing else: a second prompt cannot rename the tab away from the work
+    /// it was opened for, and a generated title or a human's replaces it
+    /// freely.
     ///
-    /// The last two still mark the session `Applied`: the answer will not
-    /// change on the next prompt, and re-deciding it every turn would only
-    /// mean rebuilding a title to throw it away.
+    /// Three things can refuse it, all ordinary rather than error cases: the
+    /// session has no prompt waiting, its pane is not resolved yet (a late
+    /// binding retries through `set_session_surface`, still carrying the FIRST
+    /// prompt), or the tab holds several terminals and no single session
+    /// speaks for it.
     pub(crate) fn apply_pending_tab_title(
         &mut self,
         ws_id: u64,
@@ -2332,12 +2333,7 @@ impl PaneFlowApp {
         let Some((title, surface_id)) = self.workspaces[ws_idx]
             .agent_sessions
             .get(&session_key)
-            .and_then(|session| match &session.tab_title_seed {
-                ai_types::TabTitleSeed::Pending(title) => {
-                    Some((title.clone(), session.surface_id?))
-                }
-                _ => None,
-            })
+            .and_then(|session| Some((session.pending_tab_title.clone()?, session.surface_id?)))
         else {
             return;
         };
@@ -2345,18 +2341,130 @@ impl PaneFlowApp {
         else {
             return;
         };
-
+        // Taken whatever `set_title` decides: a placeholder refused once (the
+        // tab is shared, or already better named) would be refused every turn,
+        // and holding it would only mean re-deciding that forever.
+        if let Some(session) = self.workspaces[ws_idx].agent_sessions.get_mut(&session_key) {
+            session.pending_tab_title = None;
+        }
         let named = surfaces == 1
             && self.workspaces[ws_idx]
                 .tab_mut(tab_idx)
-                .is_some_and(|tab| tab.set_title(&title, TabTitleSource::Auto));
-        if let Some(session) = self.workspaces[ws_idx].agent_sessions.get_mut(&session_key) {
-            session.tab_title_seed = ai_types::TabTitleSeed::Applied;
-        }
+                .is_some_and(|tab| tab.set_title(&title, TabTitleSource::Prompt));
         if named {
             self.save_session(cx);
             cx.notify();
         }
+    }
+
+    /// Read the title the agent's own CLI generated for this session, off the
+    /// render thread, and put it on the tab in place of the placeholder.
+    ///
+    /// The placeholder is the opening of the first prompt, which is a poor
+    /// name and known to be one: "Ne penses-tu pas qu'il y a" says who was
+    /// asked, not what about. A CLI worth naming a tab after already writes a
+    /// real title for its own resume picker - Claude Code's `type:"ai-title"`
+    /// record is the one read here - so the good name is a file read away
+    /// rather than a model call of our own.
+    ///
+    /// Called on every turn end until it succeeds, because the title is not
+    /// there on the first one: Claude Code writes it once it has enough of the
+    /// conversation to summarize. A session that has its title, or whose tab
+    /// can never be named, is `Settled` and reads nothing.
+    ///
+    /// Agents that generate no such title (Codex, Pi) keep the placeholder.
+    /// The scan is skipped for them rather than run and failed:
+    /// [`generated_title_source`] is the single place that says which agent
+    /// has one, and where it lives.
+    fn schedule_generated_title_scan(
+        &mut self,
+        ws_id: u64,
+        session_key: u32,
+        tool: crate::agent_launcher::TerminalAgent,
+        params: &serde_json::Value,
+        cx: &mut Context<Self>,
+    ) {
+        if self.tab_title_is_settled(ws_id, session_key, cx) {
+            return;
+        }
+        let Some(source) = generated_title_source(tool, params) else {
+            return;
+        };
+        cx.spawn(
+            async move |this: gpui::WeakEntity<Self>, cx: &mut gpui::AsyncApp| {
+                let Some(title) = smol::unblock(move || source.read()).await else {
+                    return;
+                };
+                cx.update(|cx| {
+                    let _ = this.update(cx, |app, cx| {
+                        app.apply_generated_tab_title(ws_id, session_key, &title, cx);
+                    });
+                });
+            },
+        )
+        .detach();
+    }
+
+    /// Put a generated title on the tab of `session_key`'s pane, and stop
+    /// looking for one.
+    ///
+    /// Re-resolves everything rather than trusting what the scan was launched
+    /// with: while the file was being read the pane may have moved to another
+    /// tab, the tab may have been renamed by hand, or a second agent may have
+    /// joined it. `Tab::set_title` still has the last word on a user's title.
+    fn apply_generated_tab_title(
+        &mut self,
+        ws_id: u64,
+        session_key: u32,
+        title: &str,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(ws_idx) = self.workspaces.iter().position(|ws| ws.id == ws_id) else {
+            return;
+        };
+        let Some(surface_id) = self.workspaces[ws_idx]
+            .agent_sessions
+            .get(&session_key)
+            .and_then(|session| session.surface_id)
+        else {
+            return;
+        };
+        let Some((tab_idx, surfaces)) = tab_for_surface(&self.workspaces[ws_idx], surface_id, cx)
+        else {
+            return;
+        };
+        if surfaces == 1
+            && self.workspaces[ws_idx]
+                .tab_mut(tab_idx)
+                .is_some_and(|tab| tab.set_title(title, TabTitleSource::Generated))
+        {
+            self.save_session(cx);
+            cx.notify();
+        }
+    }
+
+    /// Whether the tab holding `session_key`'s pane already carries a title no
+    /// generated one should replace - or one no scan could reach, because
+    /// several agents share the tab.
+    ///
+    /// A session whose pane is not resolved yet is NOT settled: the binding
+    /// lands within a turn, and refusing to read now would mean never reading
+    /// for an agent launched by hand.
+    fn tab_title_is_settled(&self, ws_id: u64, session_key: u32, cx: &App) -> bool {
+        let Some(ws) = self.workspaces.iter().find(|ws| ws.id == ws_id) else {
+            return false;
+        };
+        let Some(surface_id) = ws
+            .agent_sessions
+            .get(&session_key)
+            .and_then(|session| session.surface_id)
+        else {
+            return false;
+        };
+        let Some((tab_idx, surfaces)) = tab_for_surface(ws, surface_id, cx) else {
+            return false;
+        };
+        surfaces > 1 || ws.tabs().get(tab_idx).is_some_and(Tab::title_is_settled)
     }
 
     /// US-018/US-020 (orchestration-v2): push the WaitingForInput state down
@@ -3228,16 +3336,16 @@ impl PaneFlowApp {
                     ) else {
                         return stale_frame_response();
                     };
-                    // The opening prompt names the tab, so a rail of agent
-                    // rows says what each one is doing instead of repeating
-                    // the name of the CLI four times. Recorded before the
-                    // surface is resolved, and only for the FIRST prompt of
-                    // the session: later turns leave the name alone.
+                    // The opening prompt gives the tab a name to wear until
+                    // the CLI generates a real one, so a rail of agent rows
+                    // says what each one is doing instead of repeating the
+                    // name of the CLI four times. Held here until the tab is
+                    // known; `TabTitleSource::Prompt` is what keeps the second
+                    // prompt of a session from replacing the first's.
                     if let Some(session) = ws.agent_sessions.get_mut(&key)
-                        && session.tab_title_seed == ai_types::TabTitleSeed::Unseeded
                         && let Some(title) = read_hook_prompt_title(params)
                     {
-                        session.tab_title_seed = ai_types::TabTitleSeed::Pending(title);
+                        session.pending_tab_title = Some(title);
                     }
                     cx.notify();
                     self.bind_or_resolve_session_surface(
@@ -3418,6 +3526,19 @@ impl PaneFlowApp {
                     // looking elsewhere. Ctrl+C stops only clear local state.
                     let ws_title = ws.title.clone();
                     cx.notify();
+                    // A finished turn is when the CLI has had a chance to
+                    // write the session title that replaces the tab's
+                    // prompt-derived placeholder. Not on an interrupt: a
+                    // Ctrl+C turn wrote nothing new to summarize.
+                    if !interrupt_stop {
+                        self.schedule_generated_title_scan(
+                            workspace_id,
+                            session_key,
+                            tool,
+                            params,
+                            cx,
+                        );
+                    }
                     if !interrupt_stop {
                         if let Some(path) = transcript_to_read {
                             Self::schedule_transcript_turn_end(
@@ -3673,6 +3794,50 @@ fn read_frame_surface_id(params: &serde_json::Value) -> Option<u64> {
 /// [`TerminalAgent::from_binary`]. `None` for an unknown string: the frame
 /// is then ignored by the caller instead of silently retyped as Claude
 /// (the historical `from_name` fallback mislabeled every future agent).
+/// Where one agent's generated session title can be read from.
+///
+/// The single place that answers "does this CLI write a real title, and
+/// where": a variant exists only for an agent that does. Everything the read
+/// needs is captured here on the render thread, so the read itself is a pure
+/// `smol::unblock` call with no borrow of app state.
+enum GeneratedTitleSource {
+    /// Claude Code writes a `type:"ai-title"` record into the session
+    /// transcript, which is the label its own `--resume` picker shows. The
+    /// stop hook hands us that file's path.
+    ClaudeTranscript(std::path::PathBuf),
+}
+
+impl GeneratedTitleSource {
+    /// Blocking. Call from inside `smol::unblock`.
+    fn read(self) -> Option<String> {
+        match self {
+            Self::ClaudeTranscript(path) => crate::claude_sessions::read_generated_title(&path),
+        }
+    }
+}
+
+/// The generated-title source for `tool`, if it has one and this frame says
+/// where to find it.
+///
+/// Codex writes no equivalent record (see `codex_sessions`), and Pi's reader
+/// falls back to the first user message - for both, a scan could only return
+/// the placeholder the tab already shows, so there is nothing to read and the
+/// tab keeps the prompt-derived name. OpenCode DOES generate a title, but it
+/// lives behind an `opencode session list` subprocess rather than in a file
+/// the hook points at; wiring that up is a separate decision about spawning a
+/// process per turn, not an oversight.
+fn generated_title_source(
+    tool: crate::agent_launcher::TerminalAgent,
+    params: &serde_json::Value,
+) -> Option<GeneratedTitleSource> {
+    match tool {
+        crate::agent_launcher::TerminalAgent::ClaudeCode => {
+            read_transcript_path(params).map(GeneratedTitleSource::ClaudeTranscript)
+        }
+        _ => None,
+    }
+}
+
 /// The tab title carried by an `ai.prompt_submit` frame, if the agent's hook
 /// payload names its prompt `prompt` (Claude Code, Codex, Grok, Gemini). One
 /// that calls it something else simply names no tab, and its rows keep the
@@ -5660,6 +5825,57 @@ mod tests {
             serde_json::json!({ "hook_payload": { "prompt": 42 } }),
         ] {
             assert_eq!(read_hook_prompt_title(&frame), None, "{frame}");
+        }
+    }
+
+    /// Which agents a generated-title scan is even attempted for. Reading a
+    /// transcript that cannot hold a generated title is work for nothing, and
+    /// worse, its fallback would be the placeholder the tab already wears.
+    #[test]
+    fn a_generated_title_is_only_looked_for_where_one_exists() {
+        use crate::agent_launcher::TerminalAgent;
+
+        #[cfg(windows)]
+        let transcript = r"C:\abs\session.jsonl";
+        #[cfg(not(windows))]
+        let transcript = "/abs/session.jsonl";
+        let frame = serde_json::json!({
+            "hook_payload": { "transcript_path": transcript },
+        });
+
+        assert!(
+            generated_title_source(TerminalAgent::ClaudeCode, &frame).is_some(),
+            "Claude Code writes an ai-title record into the transcript"
+        );
+        for tool in [
+            TerminalAgent::Codex,
+            TerminalAgent::Pi,
+            TerminalAgent::OpenCode,
+            TerminalAgent::Gemini,
+        ] {
+            assert!(
+                generated_title_source(tool, &frame).is_none(),
+                "{tool:?} has no generated title reachable from a hook frame"
+            );
+        }
+    }
+
+    /// A frame with no transcript path names nothing rather than guessing at
+    /// one - the same absolute-path gate `read_transcript_path` applies.
+    #[test]
+    fn a_generated_title_needs_the_frame_to_say_where_to_look() {
+        use crate::agent_launcher::TerminalAgent;
+
+        for frame in [
+            serde_json::json!({}),
+            serde_json::json!({ "hook_payload": {} }),
+            serde_json::json!({ "hook_payload": { "transcript_path": "" } }),
+            serde_json::json!({ "hook_payload": { "transcript_path": "relative.jsonl" } }),
+        ] {
+            assert!(
+                generated_title_source(TerminalAgent::ClaudeCode, &frame).is_none(),
+                "{frame}"
+            );
         }
     }
 

--- a/src-app/src/app/ipc_handler.rs
+++ b/src-app/src/app/ipc_handler.rs
@@ -18,7 +18,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use gpui::{App, AppContext, BackgroundExecutor, Context, Entity, Focusable};
-use paneflow_config::schema::{LayoutNode, PaneFlowConfig, TerminalSurfaceProfile};
+use paneflow_config::schema::{LayoutNode, PaneFlowConfig, TabTitleSource, TerminalSurfaceProfile};
 use paneflow_ipc_client::ai_hook::{
     AiToolName, LifecycleEventSource, METHOD_EXIT, METHOD_NOTIFICATION, METHOD_PROMPT_SUBMIT,
     METHOD_SESSION_END, METHOD_SESSION_START, METHOD_STOP, METHOD_TOOL_USE, SessionPid, SurfaceId,
@@ -779,6 +779,31 @@ pub(crate) fn find_terminal_by_surface_id(
         }
     }
     None
+}
+
+/// The index of the tab of `ws` that holds `surface_id`, together with how
+/// many terminal surfaces that tab holds in total (its zoom-saved tree
+/// included, so zooming a pane does not change the count).
+///
+/// The count is what decides whether auto-naming may speak for the tab: in a
+/// tab split between several agents, the first one to be prompted would
+/// otherwise name the whole tab after its own task and leave the others
+/// misrepresented.
+fn tab_for_surface(ws: &Workspace, surface_id: u64, cx: &App) -> Option<(usize, usize)> {
+    ws.tabs().iter().enumerate().find_map(|(idx, tab)| {
+        let panes = tab.collect_panes();
+        let mut holds_surface = false;
+        let mut surfaces = 0;
+        for pane in &panes {
+            for terminal in pane.read(cx).terminals() {
+                surfaces += 1;
+                if terminal.entity_id().as_u64() == surface_id {
+                    holds_surface = true;
+                }
+            }
+        }
+        holds_surface.then_some((idx, surfaces))
+    })
 }
 
 fn find_terminal_in_tree(
@@ -2270,6 +2295,67 @@ impl PaneFlowApp {
             // a pane's busy verdict - refresh the Composer chip.
             self.agent_sessions_changed(cx);
             cx.notify();
+            // A session prompted before its pane was known has been holding
+            // its title since; this is the moment it can be placed.
+            self.apply_pending_tab_title(ws_id, key, cx);
+        }
+    }
+
+    /// Name the tab of `session_key`'s pane after the first prompt of that
+    /// session, if it is still waiting to be named.
+    ///
+    /// Called from the two places a naming can become possible: the prompt
+    /// arriving, and the pane behind it being resolved. Idempotent, and cheap
+    /// enough to sit on both - a session past its one naming leaves on the
+    /// first line.
+    ///
+    /// Four things can refuse the name, and all four are ordinary rather than
+    /// error cases:
+    /// - the session has already named its tab, or has no prompt yet;
+    /// - its pane is not resolved (a late binding retries through
+    ///   `set_session_surface`, still carrying the FIRST prompt);
+    /// - the tab holds several terminals, so no single session speaks for it;
+    /// - the user has named the tab, and [`Tab::set_title`] refuses.
+    ///
+    /// The last two still mark the session `Applied`: the answer will not
+    /// change on the next prompt, and re-deciding it every turn would only
+    /// mean rebuilding a title to throw it away.
+    pub(crate) fn apply_pending_tab_title(
+        &mut self,
+        ws_id: u64,
+        session_key: u32,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(ws_idx) = self.workspaces.iter().position(|ws| ws.id == ws_id) else {
+            return;
+        };
+        let Some((title, surface_id)) = self.workspaces[ws_idx]
+            .agent_sessions
+            .get(&session_key)
+            .and_then(|session| match &session.tab_title_seed {
+                ai_types::TabTitleSeed::Pending(title) => {
+                    Some((title.clone(), session.surface_id?))
+                }
+                _ => None,
+            })
+        else {
+            return;
+        };
+        let Some((tab_idx, surfaces)) = tab_for_surface(&self.workspaces[ws_idx], surface_id, cx)
+        else {
+            return;
+        };
+
+        let named = surfaces == 1
+            && self.workspaces[ws_idx]
+                .tab_mut(tab_idx)
+                .is_some_and(|tab| tab.set_title(&title, TabTitleSource::Auto));
+        if let Some(session) = self.workspaces[ws_idx].agent_sessions.get_mut(&session_key) {
+            session.tab_title_seed = ai_types::TabTitleSeed::Applied;
+        }
+        if named {
+            self.save_session(cx);
+            cx.notify();
         }
     }
 
@@ -3142,6 +3228,17 @@ impl PaneFlowApp {
                     ) else {
                         return stale_frame_response();
                     };
+                    // The opening prompt names the tab, so a rail of agent
+                    // rows says what each one is doing instead of repeating
+                    // the name of the CLI four times. Recorded before the
+                    // surface is resolved, and only for the FIRST prompt of
+                    // the session: later turns leave the name alone.
+                    if let Some(session) = ws.agent_sessions.get_mut(&key)
+                        && session.tab_title_seed == ai_types::TabTitleSeed::Unseeded
+                        && let Some(title) = read_hook_prompt_title(params)
+                    {
+                        session.tab_title_seed = ai_types::TabTitleSeed::Pending(title);
+                    }
                     cx.notify();
                     self.bind_or_resolve_session_surface(
                         workspace_id,
@@ -3149,6 +3246,12 @@ impl PaneFlowApp {
                         explicit_surface_id,
                         cx,
                     );
+                    // Not redundant with the call inside `set_session_surface`:
+                    // that one only fires when the binding CHANGES, and the
+                    // common case is a session already bound by its
+                    // `ai.session_start` frame - the surface does not move, so
+                    // this is the call that actually names the tab.
+                    self.apply_pending_tab_title(workspace_id, key, cx);
                     self.sync_attention(cx);
                     // EP-001 US-003 (cli-cockpit): the target just turned
                     // busy - refresh the Composer chip (no flush can apply).
@@ -3570,6 +3673,23 @@ fn read_frame_surface_id(params: &serde_json::Value) -> Option<u64> {
 /// [`TerminalAgent::from_binary`]. `None` for an unknown string: the frame
 /// is then ignored by the caller instead of silently retyped as Claude
 /// (the historical `from_name` fallback mislabeled every future agent).
+/// The tab title carried by an `ai.prompt_submit` frame, if the agent's hook
+/// payload names its prompt `prompt` (Claude Code, Codex, Grok, Gemini). One
+/// that calls it something else simply names no tab, and its rows keep the
+/// preset label.
+///
+/// UNTRUSTED text from a terminal-adjacent process: it is turned into a label
+/// and never interpreted. `tab_title_from_prompt` is the same sanitizer every
+/// other CLI-written title goes through, and the hook already capped the
+/// prompt on its side of the socket.
+fn read_hook_prompt_title(params: &serde_json::Value) -> Option<String> {
+    let prompt = params
+        .get("hook_payload")?
+        .get("prompt")
+        .and_then(serde_json::Value::as_str)?;
+    crate::sidebar_title::tab_title_from_prompt(prompt)
+}
+
 fn read_tool(params: &serde_json::Value) -> Option<crate::agent_launcher::TerminalAgent> {
     let tool_name = AiToolName::from_wire_params(params).ok()?;
     crate::agent_launcher::TerminalAgent::from_binary(tool_name.as_str())
@@ -5435,6 +5555,112 @@ mod tests {
             cx.update(|_, cx| find_terminal_by_surface_id(&workspaces, visible_sid, cx))
                 .is_some()
         );
+    }
+
+    /// A tab running one agent is named after that agent's first prompt; a tab
+    /// split between several is named after none of them, because no single
+    /// session speaks for it.
+    #[gpui::test]
+    fn tab_for_surface_counts_the_terminals_that_share_the_tab(cx: &mut gpui::TestAppContext) {
+        use gpui::AppContext;
+
+        let cx = cx.add_empty_window();
+        let make_pane = |cx: &mut gpui::VisualTestContext| {
+            let terminal = cx.new(|cx| crate::terminal::TerminalView::display_only_for_test(1, cx));
+            let surface_id = terminal.entity_id().as_u64();
+            let pane = cx.new(|cx| Pane::new(terminal, 1, cx));
+            (pane, surface_id)
+        };
+        let (solo_pane, solo_sid) = make_pane(cx);
+        let (shared_pane, shared_sid) = make_pane(cx);
+        let (neighbor_pane, neighbor_sid) = make_pane(cx);
+
+        let mut ws = Workspace::with_layout_and_id(
+            1,
+            "ws",
+            std::path::PathBuf::new(),
+            crate::layout::LayoutTree::Leaf(solo_pane),
+        );
+        let mut shared_tree = crate::layout::LayoutTree::Leaf(shared_pane);
+        shared_tree.split_first_leaf(crate::layout::SplitDirection::Horizontal, neighbor_pane);
+        assert!(ws.open_tab(crate::workspace::Tab::new("shared", Some(shared_tree))));
+
+        assert_eq!(
+            cx.update(|_, cx| tab_for_surface(&ws, solo_sid, cx)),
+            Some((0, 1)),
+            "the tab holds this surface and nothing else"
+        );
+        for sid in [shared_sid, neighbor_sid] {
+            assert_eq!(
+                cx.update(|_, cx| tab_for_surface(&ws, sid, cx)),
+                Some((1, 2)),
+                "both halves of the split see the same crowded tab"
+            );
+        }
+        assert_eq!(
+            cx.update(|_, cx| tab_for_surface(&ws, 999_999, cx)),
+            None,
+            "a surface that is not here resolves to no tab"
+        );
+    }
+
+    /// Zoom moves panes into `saved_layout`; a zoomed split is still a shared
+    /// tab, and forgetting the second tree would let one agent name it.
+    #[gpui::test]
+    fn tab_for_surface_counts_a_zoomed_tab_by_its_saved_layout(cx: &mut gpui::TestAppContext) {
+        use gpui::AppContext;
+
+        let cx = cx.add_empty_window();
+        let make_pane = |cx: &mut gpui::VisualTestContext| {
+            let terminal = cx.new(|cx| crate::terminal::TerminalView::display_only_for_test(1, cx));
+            let surface_id = terminal.entity_id().as_u64();
+            let pane = cx.new(|cx| Pane::new(terminal, 1, cx));
+            (pane, surface_id)
+        };
+        let (zoomed_pane, zoomed_sid) = make_pane(cx);
+        let (hidden_pane, _) = make_pane(cx);
+
+        let mut tab = crate::workspace::Tab::new(
+            "zoomed",
+            Some(crate::layout::LayoutTree::Leaf(zoomed_pane.clone())),
+        );
+        let mut saved = crate::layout::LayoutTree::Leaf(zoomed_pane);
+        saved.split_first_leaf(crate::layout::SplitDirection::Horizontal, hidden_pane);
+        tab.saved_layout = Some(saved);
+        let ws = Workspace::restored_with_id(1, "ws", std::path::PathBuf::new(), vec![tab], 0);
+
+        assert_eq!(
+            cx.update(|_, cx| tab_for_surface(&ws, zoomed_sid, cx)),
+            Some((0, 2)),
+            "the pane hidden by zoom still shares the tab"
+        );
+    }
+
+    #[test]
+    fn a_prompt_frame_yields_the_title_its_payload_carries() {
+        let frame = serde_json::json!({
+            "hook_payload": { "prompt": "fix the flaky worktree test now please" },
+        });
+        assert_eq!(
+            read_hook_prompt_title(&frame).as_deref(),
+            Some("fix the flaky worktree test now")
+        );
+    }
+
+    /// An agent whose payload names the field something else, or carries no
+    /// prompt at all, names no tab. Its rows keep the preset label - a missing
+    /// nicety, not a broken session.
+    #[test]
+    fn a_prompt_frame_without_a_usable_prompt_yields_no_title() {
+        for frame in [
+            serde_json::json!({}),
+            serde_json::json!({ "hook_payload": {} }),
+            serde_json::json!({ "hook_payload": { "user_input": "hello" } }),
+            serde_json::json!({ "hook_payload": { "prompt": "   " } }),
+            serde_json::json!({ "hook_payload": { "prompt": 42 } }),
+        ] {
+            assert_eq!(read_hook_prompt_title(&frame), None, "{frame}");
+        }
     }
 
     /// US-019: every CLI surface reported by `surface.list` carries the id and

--- a/src-app/src/app/session.rs
+++ b/src-app/src/app/session.rs
@@ -12,9 +12,10 @@ use std::sync::{Mutex, MutexGuard, PoisonError};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use gpui::{App, AppContext, Context, Entity};
-use paneflow_config::schema::LayoutNode;
+use paneflow_config::schema::{LayoutNode, TabTitleSource};
 
 use crate::PaneFlowApp;
+use crate::agent_launcher::TerminalAgent;
 use crate::launch_cwd;
 use crate::layout::{LayoutTree, MAX_PANES};
 use crate::limits::MAX_SESSION_SIZE_BYTES;
@@ -408,7 +409,11 @@ impl PaneFlowApp {
                         Self::spawn_pane_from_surfaces(ws_id, surfaces, &ws_cwd, cx)
                     })
                 });
-                tabs.push(Tab::new(tab_session.title.clone(), root));
+                tabs.push(Tab::restored(
+                    tab_session.title.clone(),
+                    restored_tab_title_source(tab_session, &ws_session.custom_buttons),
+                    root,
+                ));
             }
             let mut workspace =
                 Workspace::restored_with_id(ws_id, title.clone(), cwd, tabs, ws_session.active_tab);
@@ -736,6 +741,61 @@ fn canonicalize_persisted_layout(mut layout: LayoutNode) -> LayoutNode {
     layout
 }
 
+/// Title provenance to restore a persisted tab with.
+///
+/// A snapshot that states its provenance is believed as written - including a
+/// tab someone deliberately renamed "Claude Code", whose lock a content
+/// heuristic would cheerfully guess away.
+///
+/// `session.json` files written before auto-naming say nothing, and their
+/// titles are two different things wearing the same clothes: names people
+/// typed, and the label of whatever preset opened the tab ("Claude Code",
+/// "OpenCode", "Terminal"). Locking all of them would freeze exactly the tabs
+/// auto-naming exists for; unlocking all of them would erase names on the next
+/// prompt. So a legacy title is judged by content, and only what Paneflow
+/// itself writes is handed back to `Auto`: every agent's display name (not
+/// just the visible ones - hiding an agent in Settings must not freeze the
+/// tabs it opened), the shell and palette placeholders, the workspace's own
+/// custom command buttons, and a blank title.
+///
+/// The asymmetry is deliberate. A user who really had typed "Terminal" loses a
+/// lock they take back with one rename; the reverse mistake destroys a name
+/// with no warning and no undo. Files written from here on carry the field, so
+/// the heuristic applies once, to the snapshot that predates the feature.
+fn restored_tab_title_source(
+    tab: &paneflow_config::schema::TabSession,
+    custom_buttons: &[paneflow_config::schema::ButtonCommand],
+) -> TabTitleSource {
+    if let Some(stated) = tab.title_source {
+        return stated;
+    }
+    if is_app_written_tab_title(&tab.title)
+        || custom_buttons
+            .iter()
+            .any(|button| button.name.trim() == tab.title.trim())
+    {
+        return TabTitleSource::Auto;
+    }
+    TabTitleSource::User
+}
+
+/// Whether `title` is one Paneflow writes on its own, rather than a name a
+/// human chose. Agent-independent half of [`restored_tab_title_source`].
+fn is_app_written_tab_title(title: &str) -> bool {
+    let title = title.trim();
+    title.is_empty()
+        || title == crate::app::pane_palette::PALETTE_TAB_TITLE
+        || title == SHELL_PRESET_LABEL
+        || TerminalAgent::ALL
+            .iter()
+            .any(|agent| agent.display_name() == title)
+}
+
+/// The preset picker's label for a plain shell (`pane_palette`). Duplicated as
+/// a constant here rather than reached for through the picker's private list,
+/// which is built per workspace from live settings.
+const SHELL_PRESET_LABEL: &str = "Terminal";
+
 fn should_repair_restored_root_terminal(title: &str, cwd: &Path) -> bool {
     is_numbered_terminal_title(title) && launch_cwd::is_filesystem_root(cwd)
 }
@@ -973,6 +1033,96 @@ mod tests {
             .ok()
             .and_then(|path| path.ancestors().last().map(Path::to_path_buf))
             .unwrap_or_else(|| PathBuf::from(std::path::MAIN_SEPARATOR.to_string()))
+    }
+
+    fn legacy_tab(title: &str) -> paneflow_config::schema::TabSession {
+        serde_json::from_value(serde_json::json!({ "title": title }))
+            .expect("a title-only tab is a valid pre-auto-naming snapshot")
+    }
+
+    /// The migration that makes auto-naming reach the tabs it exists for.
+    /// Everything Paneflow itself writes into a tab title is handed back to
+    /// `Auto`, so a restored "Claude Code" tab can still be named after its
+    /// first prompt.
+    #[test]
+    fn a_legacy_preset_label_is_handed_back_to_auto_naming() {
+        for title in [
+            "",
+            "   ",
+            "Claude Code",
+            "OpenCode",
+            "Codex",
+            "Terminal",
+            "New pane",
+            // Hidden in Settings > AI Agent, yet still the label that opened
+            // the tab: visibility must not decide whether a tab stays frozen.
+            "Qoder",
+        ] {
+            assert_eq!(
+                restored_tab_title_source(&legacy_tab(title), &[]),
+                TabTitleSource::Auto,
+                "{title:?} is a label Paneflow writes, not a name a human chose"
+            );
+        }
+    }
+
+    /// The other half: a legacy title that matches nothing Paneflow writes can
+    /// only have been typed, and a build that guessed otherwise would erase it
+    /// on the next prompt with no warning and no undo.
+    #[test]
+    fn a_legacy_title_that_is_not_app_written_stays_user_owned() {
+        for title in ["sprint 3", "fix the flaky test", "claude code review"] {
+            assert_eq!(
+                restored_tab_title_source(&legacy_tab(title), &[]),
+                TabTitleSource::User,
+                "{title:?} looks like a name someone typed"
+            );
+        }
+    }
+
+    /// A workspace's custom command buttons are preset labels too - they just
+    /// live per workspace instead of in `TerminalAgent::ALL`.
+    #[test]
+    fn a_legacy_custom_button_label_is_handed_back_to_auto_naming() {
+        let buttons = vec![paneflow_config::schema::ButtonCommand {
+            id: "b1".to_string(),
+            name: "Run dev server".to_string(),
+            icon: "icons/rocket.svg".to_string(),
+            command: "bun dev".to_string(),
+        }];
+        assert_eq!(
+            restored_tab_title_source(&legacy_tab("Run dev server"), &buttons),
+            TabTitleSource::Auto
+        );
+        assert_eq!(
+            restored_tab_title_source(&legacy_tab("Run dev server"), &[]),
+            TabTitleSource::User,
+            "the button belongs to its own workspace, not to every workspace"
+        );
+    }
+
+    /// A file that states its provenance is believed as written - the label
+    /// heuristic is for the snapshot that predates the field, and must not
+    /// second-guess a lock the user asked for.
+    #[test]
+    fn an_explicit_provenance_is_taken_at_face_value() {
+        let user_named_after_a_preset: paneflow_config::schema::TabSession =
+            serde_json::from_value(serde_json::json!({
+                "title": "Claude Code",
+                "title_source": "user",
+            }))
+            .expect("valid tab snapshot");
+        assert_eq!(
+            restored_tab_title_source(&user_named_after_a_preset, &[]),
+            TabTitleSource::User,
+            "someone who types \"Claude Code\" over an auto name meant it"
+        );
+
+        let auto: paneflow_config::schema::TabSession = serde_json::from_value(
+            serde_json::json!({ "title": "sprint 3", "title_source": "auto" }),
+        )
+        .expect("valid tab snapshot");
+        assert_eq!(restored_tab_title_source(&auto, &[]), TabTitleSource::Auto);
     }
 
     #[test]

--- a/src-app/src/app/session.rs
+++ b/src-app/src/app/session.rs
@@ -774,7 +774,7 @@ fn restored_tab_title_source(
             .iter()
             .any(|button| button.name.trim() == tab.title.trim())
     {
-        return TabTitleSource::Auto;
+        return TabTitleSource::Preset;
     }
     TabTitleSource::User
 }
@@ -1060,7 +1060,7 @@ mod tests {
         ] {
             assert_eq!(
                 restored_tab_title_source(&legacy_tab(title), &[]),
-                TabTitleSource::Auto,
+                TabTitleSource::Preset,
                 "{title:?} is a label Paneflow writes, not a name a human chose"
             );
         }
@@ -1092,7 +1092,7 @@ mod tests {
         }];
         assert_eq!(
             restored_tab_title_source(&legacy_tab("Run dev server"), &buttons),
-            TabTitleSource::Auto
+            TabTitleSource::Preset
         );
         assert_eq!(
             restored_tab_title_source(&legacy_tab("Run dev server"), &[]),
@@ -1119,10 +1119,13 @@ mod tests {
         );
 
         let auto: paneflow_config::schema::TabSession = serde_json::from_value(
-            serde_json::json!({ "title": "sprint 3", "title_source": "auto" }),
+            serde_json::json!({ "title": "sprint 3", "title_source": "preset" }),
         )
         .expect("valid tab snapshot");
-        assert_eq!(restored_tab_title_source(&auto, &[]), TabTitleSource::Auto);
+        assert_eq!(
+            restored_tab_title_source(&auto, &[]),
+            TabTitleSource::Preset
+        );
     }
 
     #[test]

--- a/src-app/src/app/sidebar/context_menu.rs
+++ b/src-app/src/app/sidebar/context_menu.rs
@@ -401,10 +401,17 @@ impl PaneFlowApp {
     /// entry is gone along with the tab strip that anchored it: what remains
     /// are the surface actions (copy path, cancel a queued prompt, close the
     /// pane). No dead or disabled move entry is left behind.
-    /// US-010: right-click menu on a sidebar tab row. Two entries - Rename and
-    /// Close - in the shared select-menu language of the workspace menu. Close
-    /// keeps FR-01: the last tab of a workspace is replaced by an empty one,
-    /// the workspace itself is never closed from here.
+    /// US-010: right-click menu on a sidebar tab row. Rename and Close, in the
+    /// shared select-menu language of the workspace menu, plus "Reset name" on
+    /// a tab the user has named. Close keeps FR-01: the last tab of a
+    /// workspace is replaced by an empty one, the workspace itself is never
+    /// closed from here.
+    ///
+    /// "Reset name" is the way back out of the naming lock. Renaming a tab
+    /// freezes it against auto-naming for good, which is the point - but a
+    /// one-way door would leave a tab named after a task that ended three
+    /// tasks ago, with nothing to do about it. It only appears where it does
+    /// something, so an auto-named tab shows the same two entries as before.
     pub(crate) fn render_tab_context_menu(
         &self,
         menu: TabContextMenu,
@@ -417,7 +424,13 @@ impl PaneFlowApp {
             tab_idx,
             position,
         } = menu;
-        let menu_height = px(8. + 2. * 28.);
+        let can_reset_name = self
+            .workspaces
+            .get(ws_idx)
+            .and_then(|ws| ws.tabs().get(tab_idx))
+            .is_some_and(|tab| tab.title_is_user_owned());
+        let rows = if can_reset_name { 3. } else { 2. };
+        let menu_height = px(8. + rows * 28.);
         let menu_pos = clamped_context_menu_position(position, px(248.), menu_height, window);
         let close_shortcut = self
             .shortcut_for_action("close_tab")
@@ -445,6 +458,19 @@ impl PaneFlowApp {
                     cx.stop_propagation();
                 }),
             ))
+            .when(can_reset_name, |menu| {
+                menu.child(self.render_select_menu_item(
+                    "tab-context-reset-name".into(),
+                    "Reset name",
+                    None,
+                    ui,
+                    cx.listener(move |this, _: &ClickEvent, _window, cx| {
+                        this.tab_menu_open = None;
+                        this.reset_tab_name(ws_idx, tab_idx, cx);
+                        cx.stop_propagation();
+                    }),
+                ))
+            })
             .child(self.render_select_menu_item(
                 "tab-context-close".into(),
                 "Close",

--- a/src-app/src/app/sidebar/mod.rs
+++ b/src-app/src/app/sidebar/mod.rs
@@ -517,10 +517,10 @@ fn tab_pane_icon(pane: &crate::pane::Pane, cx: &gpui::App) -> TabPaneIcon {
 /// or created from a named preset) falls back to its 1-based position, so the
 /// list never shows a blank row.
 fn tab_display_title(tab: &Tab, tab_idx: usize) -> String {
-    if tab.title.trim().is_empty() {
+    if tab.title().trim().is_empty() {
         format!("Tab {}", tab_idx + 1)
     } else {
-        tab.title.clone()
+        tab.title().to_string()
     }
 }
 
@@ -558,23 +558,10 @@ fn sidebar_drop_slots(rows: &[SidebarRow], workspace_count: usize) -> Vec<Sideba
 }
 
 impl PaneFlowApp {
-    fn begin_workspace_rename(&mut self, index: usize, cx: &mut Context<Self>) {
-        self.commit_rename(cx);
-        if let Some(title) = self
-            .workspaces
-            .get(index)
-            .map(|workspace| workspace.title.clone())
-        {
-            self.rename_input
-                .update(cx, |input, cx| input.set_value(title, cx));
-            self.renaming_idx = Some(index);
-        }
-    }
-
-    /// Issue #32: the inline rename box hosts the shared `rename_input`
-    /// widget. The row above it owns the enter/escape handling, and the mouse
-    /// guards keep a click inside the field from reaching the row's click,
-    /// drag, and context-menu listeners.
+    /// Issue #32: the inline rename box hosts the `rename_input` widget. The
+    /// row above it owns the enter/escape handling, and the mouse guards keep
+    /// a click inside the field from reaching the row's click, drag, and
+    /// context-menu listeners.
     fn inline_rename_field(&self, ui: crate::theme::UiColors) -> gpui::Div {
         div()
             .flex_1()
@@ -987,20 +974,17 @@ impl PaneFlowApp {
                 if let Some(workspace) = this.workspaces.get_mut(idx) {
                     workspace.agent_completion_notification.acknowledge();
                 }
-                let is_double = matches!(e, ClickEvent::Mouse(m) if m.down.click_count == 2);
-                if is_double {
-                    this.begin_workspace_rename(idx, cx);
-                } else {
-                    let was_renaming = this.renaming_idx == Some(idx);
-                    this.commit_rename(cx);
-                    this.select_workspace(idx, window, cx);
-                    // US-008: the whole card is the disclosure control, not just
-                    // the folder icon. Committing a rename is exempt: that click
-                    // ends an edit, and folding the row under the cursor would
-                    // read as a side effect of typing a name.
-                    if !was_renaming {
-                        this.toggle_workspace_expanded(idx, cx);
-                    }
+                let was_renaming = this.renaming_tab.is_some();
+                this.commit_rename(cx);
+                this.select_workspace(idx, window, cx);
+                // US-008: the whole card is the disclosure control, not just
+                // the folder icon. Two clicks are exempt on either count: the
+                // second half of a double-click would fold the row straight
+                // back, and committing a rename ends an edit - folding the row
+                // under the cursor would read as a side effect of typing.
+                let is_double = matches!(e, ClickEvent::Mouse(m) if m.down.click_count >= 2);
+                if !was_renaming && !is_double {
+                    this.toggle_workspace_expanded(idx, cx);
                 }
                 cx.notify();
             }))
@@ -1013,28 +997,6 @@ impl PaneFlowApp {
                     this.workspace_menu_open = Some(WorkspaceContextMenu { idx, position });
                     cx.stop_propagation();
                     cx.notify();
-                }
-            }))
-            // Issue #32: the row only sits on the focus path while its own
-            // rename field is focused, so this handler is exactly the
-            // enter/escape pair. Everything else - text entry, caret, IME,
-            // clipboard - belongs to the `TextInput` below it.
-            .on_key_down(cx.listener(move |this, e: &KeyDownEvent, _window, cx| {
-                if this.renaming_idx != Some(idx) {
-                    return;
-                }
-                match e.keystroke.key.as_str() {
-                    "enter" => {
-                        this.commit_rename(cx);
-                        cx.stop_propagation();
-                        cx.notify();
-                    }
-                    "escape" => {
-                        this.renaming_idx = None;
-                        cx.stop_propagation();
-                        cx.notify();
-                    }
-                    _ => {}
                 }
             }));
 
@@ -1050,21 +1012,19 @@ impl PaneFlowApp {
             folder_sessions(),
             ws.agent_completion_notification.is_unread(),
         );
-        let title_el = if self.renaming_idx == Some(i) {
-            self.inline_rename_field(ui).font_weight(FontWeight::MEDIUM)
-        } else {
-            div()
-                .flex_1()
-                .min_w_0()
-                .overflow_x_hidden()
-                .whitespace_nowrap()
-                .text_ellipsis()
-                .text_color(ui.text)
-                .text_sm()
-                .line_height(px(SIDEBAR_ROW_LINE_HEIGHT))
-                .font_weight(FontWeight::MEDIUM)
-                .child(title)
-        };
+        // A folder row carries the directory's own name and never an edit box:
+        // the workspace title is derived from the folder, not typed.
+        let title_el = div()
+            .flex_1()
+            .min_w_0()
+            .overflow_x_hidden()
+            .whitespace_nowrap()
+            .text_ellipsis()
+            .text_color(ui.text)
+            .text_sm()
+            .line_height(px(SIDEBAR_ROW_LINE_HEIGHT))
+            .font_weight(FontWeight::MEDIUM)
+            .child(title);
 
         // US-008: the open/closed folder glyph reports the disclosure state -
         // no chevron beside it, and no click target of its own. The whole card

--- a/src-app/src/app/workspace_ops/mod.rs
+++ b/src-app/src/app/workspace_ops/mod.rs
@@ -20,7 +20,7 @@ mod swap;
 mod tab;
 
 use gpui::{App, AppContext, ClipboardItem, Context, Entity, Focusable, PathPromptOptions, Window};
-use paneflow_config::schema::TerminalSurfaceProfile;
+use paneflow_config::schema::{TabTitleSource, TerminalSurfaceProfile};
 use paneflow_process::spawn_detached;
 
 use crate::layout::{LayoutTree, MAX_PANES, SplitDirection};
@@ -916,29 +916,26 @@ impl PaneFlowApp {
         cx.notify();
     }
 
+    /// US-010: settle the sidebar's inline rename, if one is live.
+    ///
+    /// Only a tab is renameable, and the title it takes here is the one kind
+    /// nothing else may overwrite: [`TabTitleSource::User`] locks the tab out
+    /// of auto-naming for good (see [`crate::workspace::Tab::set_title`]).
     pub(crate) fn commit_rename(&mut self, cx: &App) {
-        if let Some(idx) = self.renaming_idx.take() {
-            let text = self.rename_input.read(cx).value().trim().to_string();
-            if !text.is_empty()
-                && let Some(ws) = self.workspaces.get_mut(idx)
-            {
-                ws.title = text;
-                self.save_session(cx);
-            }
+        let Some((ws_idx, tab_idx)) = self.renaming_tab.take() else {
+            return;
+        };
+        let text = self.rename_input.read(cx).value().trim().to_string();
+        if text.is_empty() {
+            return;
         }
-        // US-010: the sidebar tab rows share `rename_input` with the workspace
-        // rename, so one commit settles whichever inline rename was live.
-        if let Some((ws_idx, tab_idx)) = self.renaming_tab.take() {
-            let text = self.rename_input.read(cx).value().trim().to_string();
-            if !text.is_empty()
-                && let Some(tab) = self
-                    .workspaces
-                    .get_mut(ws_idx)
-                    .and_then(|ws| ws.tab_mut(tab_idx))
-            {
-                tab.title = text;
-                self.save_session(cx);
-            }
+        if self
+            .workspaces
+            .get_mut(ws_idx)
+            .and_then(|ws| ws.tab_mut(tab_idx))
+            .is_some_and(|tab| tab.set_title(&text, TabTitleSource::User))
+        {
+            self.save_session(cx);
         }
     }
 

--- a/src-app/src/app/workspace_ops/tab.rs
+++ b/src-app/src/app/workspace_ops/tab.rs
@@ -69,10 +69,11 @@ impl PaneFlowApp {
             let active = ws.active_tab_mut();
             if active.root.is_none() && active.saved_layout.is_none() {
                 // The preset label is Paneflow naming the tab, not the user:
-                // `Auto` keeps it replaceable by the first prompt's subject.
-                // It must not overwrite a title the user typed on the empty
-                // tab they are filling, which `set_title` already refuses.
-                active.set_title(&title, TabTitleSource::Auto);
+                // the weakest rank, so the first prompt's subject and then the
+                // CLI's own session title both replace it. It must not
+                // overwrite a title the user typed on the empty tab they are
+                // filling, which `set_title` already refuses.
+                active.set_title(&title, TabTitleSource::Preset);
                 active.root = Some(root);
                 true
             } else {

--- a/src-app/src/app/workspace_ops/tab.rs
+++ b/src-app/src/app/workspace_ops/tab.rs
@@ -11,7 +11,7 @@
 //! two drifting ones.
 
 use gpui::{AppContext, Context, Window};
-use paneflow_config::schema::TerminalSurfaceProfile;
+use paneflow_config::schema::{TabTitleSource, TerminalSurfaceProfile};
 
 use crate::PaneFlowApp;
 use crate::layout::LayoutTree;
@@ -68,7 +68,11 @@ impl PaneFlowApp {
         let opened = self.workspaces.get_mut(ws_idx).is_some_and(|ws| {
             let active = ws.active_tab_mut();
             if active.root.is_none() && active.saved_layout.is_none() {
-                active.title = title;
+                // The preset label is Paneflow naming the tab, not the user:
+                // `Auto` keeps it replaceable by the first prompt's subject.
+                // It must not overwrite a title the user typed on the empty
+                // tab they are filling, which `set_title` already refuses.
+                active.set_title(&title, TabTitleSource::Auto);
                 active.root = Some(root);
                 true
             } else {
@@ -270,7 +274,7 @@ impl PaneFlowApp {
             .workspaces
             .get(ws_idx)
             .and_then(|ws| ws.tabs().get(tab_idx))
-            .map(|tab| tab.title.clone())
+            .map(|tab| tab.title().to_string())
         else {
             return;
         };
@@ -278,6 +282,21 @@ impl PaneFlowApp {
             .update(cx, |input, cx| input.set_value(title, cx));
         self.renaming_tab = Some((ws_idx, tab_idx));
         cx.notify();
+    }
+
+    /// Hand a user-named tab back to auto-naming (the tab menu's "Reset
+    /// name"). The visible text stays until something automatic replaces it,
+    /// so the row does not blink back to its `Tab N` fallback.
+    pub(crate) fn reset_tab_name(&mut self, ws_idx: usize, tab_idx: usize, cx: &mut Context<Self>) {
+        if self
+            .workspaces
+            .get_mut(ws_idx)
+            .and_then(|ws| ws.tab_mut(tab_idx))
+            .is_some_and(Tab::unlock_title)
+        {
+            self.save_session(cx);
+            cx.notify();
+        }
     }
 
     /// US-011: reorder a dragged tab inside its own workspace. `target_idx` is

--- a/src-app/src/claude_sessions.rs
+++ b/src-app/src/claude_sessions.rs
@@ -291,12 +291,51 @@ fn read_session_meta(path: &Path) -> Option<SessionMeta> {
     read_session_meta_inner(path, false)
 }
 
+/// The LLM-generated title of the session at `path`, and ONLY that.
+///
+/// Auto-naming a tab wants the real thing or nothing: the first-user-message
+/// fallback [`read_session_meta`] falls back to is exactly the placeholder the
+/// tab already shows, so accepting it would end the search having changed
+/// nothing. `None` here means "not written yet, ask again after the next
+/// turn", which is a state the caller must be able to tell from success.
+///
+/// Blocking file I/O - call from inside `smol::unblock`.
+pub fn read_generated_title(path: &Path) -> Option<String> {
+    scan_session_head(path, false)?.ai_title
+}
+
+/// What one pass over a session file's head yields, before it is composed
+/// into a [`SessionMeta`]. Keeping the generated title and the first-message
+/// fallback apart is the point: by the time they are folded into
+/// `SessionMeta::summary` there is no telling which one won.
+struct SessionHead {
+    envelope: FirstLineEnvelope,
+    ai_title: Option<String>,
+    user_fallback: Option<String>,
+    model: Option<String>,
+    usage: Option<AssistantUsage>,
+}
+
 /// Shared session-head scan. `scan_usage = false` is the title-only popover
 /// path: bounded by [`TITLE_SCAN_LIMIT`], it stops as soon as the envelope +
 /// title are known. `scan_usage = true` is the EP-004 attribution path: it
 /// walks past the title (bounded by [`MODEL_USAGE_SCAN_LIMIT`]) aggregating
 /// `message.usage` across assistant turns and capturing `message.model`.
 fn read_session_meta_inner(path: &Path, scan_usage: bool) -> Option<SessionMeta> {
+    let head = scan_session_head(path, scan_usage)?;
+    Some(SessionMeta {
+        agent: SessionAgent::Claude,
+        session_id: head.envelope.session_id,
+        timestamp: head.envelope.timestamp,
+        cwd: head.envelope.cwd,
+        git_branch: head.envelope.git_branch,
+        summary: head.ai_title.or(head.user_fallback),
+        model: head.model,
+        usage: head.usage,
+    })
+}
+
+fn scan_session_head(path: &Path, scan_usage: bool) -> Option<SessionHead> {
     let file = fs::File::open(path).ok()?;
     let mut reader = BufReader::new(file);
     let mut buf = String::new();
@@ -491,16 +530,10 @@ fn read_session_meta_inner(path: &Path, scan_usage: bool) -> Option<SessionMeta>
         }
     }
 
-    let envelope = envelope?;
-    let summary = ai_title.or(user_fallback);
-
-    Some(SessionMeta {
-        agent: SessionAgent::Claude,
-        session_id: envelope.session_id,
-        timestamp: envelope.timestamp,
-        cwd: envelope.cwd,
-        git_branch: envelope.git_branch,
-        summary,
+    Some(SessionHead {
+        envelope: envelope?,
+        ai_title,
+        user_fallback,
         model,
         usage: saw_usage.then_some(usage),
     })
@@ -678,6 +711,54 @@ mod tests {
         assert_eq!(meta.timestamp, "2026-04-26T13:38:41.095Z");
         assert_eq!(meta.git_branch, "main");
         assert_eq!(meta.summary.as_deref(), Some("Implement feature X"));
+    }
+
+    /// Tab naming wants the generated title or nothing. Returning the
+    /// first-user-message fallback would hand back exactly the placeholder the
+    /// tab already shows, and the caller would take it for success and stop
+    /// looking for the real one.
+    #[test]
+    fn read_generated_title_refuses_the_first_message_fallback() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let envelope = r#"{"parentUuid":null,"type":"user","message":{"role":"user","content":"Ne penses-tu pas qu'il y a trop de features"},"uuid":"u","timestamp":"2026-04-26T13:38:41.095Z","cwd":"/tmp/proj","sessionId":"s"}"#;
+
+        let untitled = dir.path().join("untitled.jsonl");
+        std::fs::write(&untitled, format!("{envelope}\n")).expect("write fixture");
+        assert_eq!(
+            read_generated_title(&untitled),
+            None,
+            "no ai-title yet means ask again after the next turn"
+        );
+        assert_eq!(
+            read_session_meta(&untitled)
+                .expect("meta")
+                .summary
+                .as_deref(),
+            Some("Ne penses-tu pas qu'il y a trop de features"),
+            "the sessions popover still gets its fallback label"
+        );
+
+        let titled = dir.path().join("titled.jsonl");
+        std::fs::write(
+            &titled,
+            format!(
+                "{envelope}\n{}\n",
+                r#"{"type":"ai-title","aiTitle":"Pyxis feature-count review","sessionId":"s"}"#
+            ),
+        )
+        .expect("write fixture");
+        assert_eq!(
+            read_generated_title(&titled).as_deref(),
+            Some("Pyxis feature-count review")
+        );
+    }
+
+    #[test]
+    fn read_generated_title_survives_a_missing_file() {
+        assert_eq!(
+            read_generated_title(std::path::Path::new("/nonexistent/session.jsonl")),
+            None
+        );
     }
 
     #[test]

--- a/src-app/src/main.rs
+++ b/src-app/src/main.rs
@@ -868,10 +868,12 @@ struct DiffDockState {
 struct PaneFlowApp {
     workspaces: Vec<Workspace>,
     active_idx: usize,
-    renaming_idx: Option<usize>,
     /// US-010: sidebar tab being renamed inline, as `(workspace_idx, tab_idx)`.
-    /// Shares `rename_input` with the workspace rename - only one inline rename
-    /// can be live at a time, and `commit_rename` settles whichever is.
+    ///
+    /// A tab is the ONLY thing the sidebar renames. A workspace takes its name
+    /// from the folder it holds (`Workspace::title`, derived from the directory
+    /// at open time), so letting it drift from that folder would leave the rail
+    /// claiming a name nothing on disk answers to, with no way back.
     renaming_tab: Option<(usize, usize)>,
     /// Issue #32: the inline rename box is a real `TextInput`, not a text
     /// mirror fed by the row's `on_key_down`. GPUI dispatches key events along
@@ -1494,7 +1496,7 @@ impl Render for PaneFlowApp {
         // its keys back once the edit is over, so both transitions are driven
         // here rather than from the row listeners (which have no `Window`).
         let rename_focus = self.rename_input.read(cx).focus_handle.clone();
-        let rename_live = self.renaming_idx.is_some() || self.renaming_tab.is_some();
+        let rename_live = self.renaming_tab.is_some();
         if rename_live != self.rename_focus_live {
             self.rename_focus_live = rename_live;
             if rename_live {

--- a/src-app/src/sidebar_title.rs
+++ b/src-app/src/sidebar_title.rs
@@ -9,6 +9,17 @@
 /// Longest title a sidebar row keeps; the rest is elided with `…`.
 const MAX_SIDEBAR_TITLE_CHARS: usize = 240;
 
+/// Words a tab title keeps from the prompt that opened the session.
+///
+/// Enough to tell "fix the flaky worktree test" from "add the release
+/// checksum job", short enough that a rail full of them stays scannable.
+const PROMPT_TITLE_WORDS: usize = 6;
+
+/// And a character ceiling for those words, since six of them can still be
+/// six identifiers. Well under [`MAX_SIDEBAR_TITLE_CHARS`]: this one is about
+/// what a person reads at a glance, not about bounding a buffer.
+const PROMPT_TITLE_MAX_CHARS: usize = 48;
+
 /// Strip leading decoration glyphs and invisible characters that CLI
 /// agents (Claude Code, Codex, OpenCode, Pi, Amp) bake into their
 /// session / OSC titles to indicate status. Without this:
@@ -105,6 +116,47 @@ fn is_title_meaningful_lead(c: char) -> bool {
         )
 }
 
+/// A tab title made from the first prompt of a session.
+///
+/// The opening words of what was asked, which is what tells one agent tab
+/// from another - the alternative being a rail of identical "Claude Code"
+/// rows. Deliberately not a summary: no model runs here, so naming costs
+/// nothing and cannot be slow, wrong, or unavailable.
+///
+/// `prompt` is UNTRUSTED text from the agent's hook payload. It goes through
+/// the same [`clean_sidebar_title`] every other CLI-written label does, which
+/// neutralizes control and bidi characters, folds the newlines a pasted
+/// prompt carries, and strips leading decoration.
+///
+/// Returns `None` when nothing usable remains - the caller leaves the tab's
+/// current title alone rather than blanking it.
+pub fn tab_title_from_prompt(prompt: &str) -> Option<String> {
+    let cleaned = clean_sidebar_title(prompt)?;
+    let mut title = String::new();
+    for word in cleaned.split_whitespace().take(PROMPT_TITLE_WORDS) {
+        // Keep whole words: a title cut mid-identifier reads as corruption
+        // rather than as an abbreviation. The first word is kept whatever its
+        // length, so a single very long one still names the tab.
+        if !title.is_empty()
+            && title.chars().count() + 1 + word.chars().count() > PROMPT_TITLE_MAX_CHARS
+        {
+            break;
+        }
+        if !title.is_empty() {
+            title.push(' ');
+        }
+        title.push_str(word);
+    }
+    if title.is_empty() {
+        return None;
+    }
+    if title.chars().count() > PROMPT_TITLE_MAX_CHARS {
+        title = title.chars().take(PROMPT_TITLE_MAX_CHARS).collect();
+        title.push('…');
+    }
+    Some(title)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -126,5 +178,74 @@ mod tests {
     #[test]
     fn pure_decoration_leaves_nothing() {
         assert_eq!(clean_sidebar_title("●  \u{200B}"), None);
+    }
+
+    #[test]
+    fn a_prompt_title_keeps_the_opening_words() {
+        assert_eq!(
+            tab_title_from_prompt("fix the flaky worktree test").as_deref(),
+            Some("fix the flaky worktree test")
+        );
+        assert_eq!(
+            tab_title_from_prompt(
+                "rewrite the session restore path so a legacy snapshot keeps its titles"
+            )
+            .as_deref(),
+            Some("rewrite the session restore path so"),
+            "six words, and no seventh"
+        );
+    }
+
+    /// A pasted prompt arrives with newlines and indentation; a tab row is one
+    /// line.
+    #[test]
+    fn a_multiline_prompt_becomes_one_line() {
+        let title = tab_title_from_prompt("update the changelog\n\n  - add EP-004\n  - bump")
+            .expect("a usable title");
+        assert_eq!(title, "update the changelog - add EP-004");
+        assert!(!title.contains('\n'));
+    }
+
+    /// Six words can still be six identifiers, and a rail is not a paragraph.
+    #[test]
+    fn a_prompt_title_stays_within_its_character_budget() {
+        let title = tab_title_from_prompt(
+            "refactor TerminalSessionBackend AbstractSyntaxTreeVisitor ConfigurationLoader now",
+        )
+        .expect("a usable title");
+        assert!(
+            title.chars().count() <= PROMPT_TITLE_MAX_CHARS + 1,
+            "{title:?} overruns the budget"
+        );
+        assert!(
+            !title.contains("ConfigurationLoader"),
+            "{title:?} should have stopped at a word boundary"
+        );
+    }
+
+    /// One word longer than the whole budget still names the tab - refusing
+    /// would leave the row on its "Tab 3" fallback for no good reason.
+    #[test]
+    fn a_single_overlong_word_is_elided_rather_than_dropped() {
+        let word = "x".repeat(PROMPT_TITLE_MAX_CHARS + 20);
+        let title = tab_title_from_prompt(&word).expect("a usable title");
+        assert_eq!(title.chars().count(), PROMPT_TITLE_MAX_CHARS + 1);
+        assert!(title.ends_with('…'));
+    }
+
+    /// The prompt is untrusted text on its way to a label: the same
+    /// neutralization every other CLI-written title gets.
+    #[test]
+    fn a_prompt_title_is_sanitized_like_any_other_label() {
+        let title =
+            tab_title_from_prompt("● \u{202E}drop the table\u{200B} now").expect("a usable title");
+        assert_eq!(title, "drop the table now");
+    }
+
+    #[test]
+    fn a_prompt_with_nothing_usable_names_nothing() {
+        assert_eq!(tab_title_from_prompt(""), None);
+        assert_eq!(tab_title_from_prompt("   \n\t "), None);
+        assert_eq!(tab_title_from_prompt("●  \u{200B}"), None);
     }
 }

--- a/src-app/src/update/linux/system_package.rs
+++ b/src-app/src/update/linux/system_package.rs
@@ -1140,9 +1140,9 @@ mod tests {
     /// tempdir must stay alive for the duration of the test so
     /// the script file is not deleted out from under `Command`.
     ///
-    /// The write is an explicit `File::create + write_all + sync_all
-    /// + drop` rather than the terser `fs::write`, and permissions
-    /// are set AFTER the parent handle is fully closed. On Linux,
+    /// The write is an explicit `File::create + write_all +
+    /// sync_all + drop` rather than the terser `fs::write`, and
+    /// permissions are set AFTER the parent handle is closed. On Linux,
     /// `exec(2)` returns `ETXTBSY` ("Text file busy", OS error 26) if
     /// any process has a write handle open to the target file. A spawn
     /// concurrent with this write window can fork and inherit that

--- a/src-app/src/workspace/mod.rs
+++ b/src-app/src/workspace/mod.rs
@@ -364,7 +364,7 @@ impl Workspace {
     /// place instead of leaving it behind.
     pub fn is_empty_shell(&self) -> bool {
         match self.tabs.as_slice() {
-            [tab] => tab.title.is_empty() && tab.root.is_none() && tab.saved_layout.is_none(),
+            [tab] => tab.title().is_empty() && tab.root.is_none() && tab.saved_layout.is_none(),
             _ => false,
         }
     }
@@ -489,7 +489,8 @@ impl Workspace {
         self.tabs
             .iter()
             .map(|tab| TabSession {
-                title: tab.title.clone(),
+                title: tab.title().to_string(),
+                title_source: Some(tab.title_source()),
                 layout: tab.serialize_without_scrollback(cx),
             })
             .collect()
@@ -689,7 +690,7 @@ mod tests {
             "the placeholder is filled, not pushed past"
         );
         assert_eq!(ws.active_tab_idx(), 0);
-        assert_eq!(ws.active_tab().title, "first");
+        assert_eq!(ws.active_tab().title(), "first");
         assert!(!ws.is_empty_shell());
 
         assert!(ws.open_tab(Tab::new("second", None)));

--- a/src-app/src/workspace/tab.rs
+++ b/src-app/src/workspace/tab.rs
@@ -7,7 +7,7 @@
 //! now operate one level down.
 
 use gpui::{App, Entity, Window};
-use paneflow_config::schema::LayoutNode;
+use paneflow_config::schema::{LayoutNode, TabTitleSource};
 
 use crate::layout::LayoutTree;
 use crate::pane::Pane;
@@ -28,7 +28,14 @@ pub struct Tab {
     pub id: u64,
     /// User-facing title. Empty means "unnamed" - the sidebar derives a
     /// fallback label (US-009).
-    pub title: String,
+    ///
+    /// Private on purpose: [`Self::set_title`] is the ONE way a title changes,
+    /// and it is where "a name a human typed is never overwritten" is
+    /// enforced. A `pub` field would put that rule back in the hands of every
+    /// caller, which is how such rules quietly stop holding.
+    title: String,
+    /// Who wrote [`Self::title`]. See [`TabTitleSource`].
+    title_source: TabTitleSource,
     /// Pane layout tree. `None` for an empty tab (every pane closed).
     pub root: Option<LayoutTree>,
     /// Saved layout tree while zoomed. `Some(tree)` means this tab is zoomed
@@ -38,12 +45,34 @@ pub struct Tab {
 
 impl Tab {
     /// Create a tab holding `root`, with a freshly allocated id.
+    ///
+    /// The title is [`TabTitleSource::Auto`]: every in-process construction
+    /// site is Paneflow naming the tab itself (a preset label, the palette
+    /// placeholder, an empty string). A human's title only ever arrives
+    /// through [`Self::set_title`], or from the restore path via
+    /// [`Self::restored`].
     pub fn new(title: impl Into<String>, root: Option<LayoutTree>) -> Self {
         Self {
             id: next_tab_id(),
             title: title.into(),
+            title_source: TabTitleSource::Auto,
             root,
             saved_layout: None,
+        }
+    }
+
+    /// Rebuild a tab from a session snapshot, carrying the persisted title
+    /// provenance across the restart. Without this, every restored tab would
+    /// look app-named and the first prompt of the next session would erase a
+    /// name the user typed days ago.
+    pub fn restored(
+        title: impl Into<String>,
+        title_source: TabTitleSource,
+        root: Option<LayoutTree>,
+    ) -> Self {
+        Self {
+            title_source,
+            ..Self::new(title, root)
         }
     }
 
@@ -52,6 +81,64 @@ impl Tab {
     /// closed.
     pub fn empty() -> Self {
         Self::new(String::new(), None)
+    }
+
+    /// The tab's stored title. Empty means unnamed; the sidebar derives the
+    /// visible fallback (US-009).
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    pub fn title_source(&self) -> TabTitleSource {
+        self.title_source
+    }
+
+    /// Whether this title belongs to the user and is therefore frozen against
+    /// every automatic naming path.
+    pub fn title_is_user_owned(&self) -> bool {
+        self.title_source == TabTitleSource::User
+    }
+
+    /// The single write path for a tab title. Returns whether anything
+    /// changed, so callers persist the session only on a real delta.
+    ///
+    /// Rules, in order:
+    /// 1. An automatic title never overwrites a user's. This is the whole
+    ///    point of the type, and it is checked here rather than at each call
+    ///    site so no future caller can forget it.
+    /// 2. An automatic title never *clears* one. A summarizer that returns
+    ///    nothing must leave the tab as it is, not blank it.
+    /// 3. Titles are stored trimmed, and a no-op write reports `false` -
+    ///    every turn of an agent would otherwise schedule a session save that
+    ///    writes the same bytes.
+    pub fn set_title(&mut self, title: &str, source: TabTitleSource) -> bool {
+        let title = title.trim();
+        if source != TabTitleSource::User {
+            if self.title_is_user_owned() || title.is_empty() {
+                return false;
+            }
+        } else if title.is_empty() {
+            return false;
+        }
+        if self.title == title && self.title_source == source {
+            return false;
+        }
+        self.title.clear();
+        self.title.push_str(title);
+        self.title_source = source;
+        true
+    }
+
+    /// Hand a user-owned title back to auto-naming (the tab menu's "Reset
+    /// name"). Returns whether anything changed.
+    ///
+    /// The text is deliberately kept: dropping it would flash the tab back to
+    /// its "Tab 3" fallback until the next turn produced a name. Only the
+    /// ownership changes, so the next automatic title may take over.
+    pub fn unlock_title(&mut self) -> bool {
+        let was_locked = self.title_is_user_owned();
+        self.title_source = TabTitleSource::Auto;
+        was_locked
     }
 
     pub fn is_zoomed(&self) -> bool {
@@ -146,5 +233,106 @@ impl Tab {
     pub fn serialize_without_scrollback(&self, cx: &App) -> Option<LayoutNode> {
         let tree = self.saved_layout.as_ref().or(self.root.as_ref())?;
         Some(tree.serialize_without_scrollback(cx))
+    }
+}
+
+/// The title-ownership rule, tested at the one place that enforces it.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tab(title: &str) -> Tab {
+        Tab::new(title, None)
+    }
+
+    #[test]
+    fn auto_titles_replace_each_other() {
+        let mut tab = tab("Claude Code");
+        assert!(tab.set_title("wire up the parser", TabTitleSource::Auto));
+        assert_eq!(tab.title(), "wire up the parser");
+        assert!(tab.set_title("rewrite the lexer", TabTitleSource::Auto));
+        assert_eq!(tab.title(), "rewrite the lexer");
+    }
+
+    #[test]
+    fn a_user_title_is_never_overwritten_by_an_automatic_one() {
+        let mut tab = tab("Claude Code");
+        assert!(tab.set_title("sprint 3", TabTitleSource::User));
+
+        assert!(!tab.set_title("wire up the parser", TabTitleSource::Auto));
+        assert_eq!(tab.title(), "sprint 3");
+        assert!(tab.title_is_user_owned());
+    }
+
+    #[test]
+    fn a_user_title_can_be_replaced_by_another_user_title() {
+        let mut tab = tab("");
+        assert!(tab.set_title("sprint 3", TabTitleSource::User));
+        assert!(tab.set_title("sprint 4", TabTitleSource::User));
+        assert_eq!(tab.title(), "sprint 4");
+    }
+
+    /// A summarizer that returns nothing must leave the tab alone rather than
+    /// blank it - the sidebar would fall back to "Tab 2" out of nowhere.
+    #[test]
+    fn an_automatic_title_never_clears_one() {
+        let mut tab = tab("OpenCode");
+        assert!(!tab.set_title("", TabTitleSource::Auto));
+        assert!(!tab.set_title("   \n ", TabTitleSource::Auto));
+        assert_eq!(tab.title(), "OpenCode");
+    }
+
+    /// Every agent turn would otherwise schedule a session write of identical
+    /// bytes.
+    #[test]
+    fn an_unchanged_title_reports_no_change() {
+        let mut tab = tab("Codex");
+        assert!(!tab.set_title("Codex", TabTitleSource::Auto));
+        assert!(!tab.set_title("  Codex  ", TabTitleSource::Auto));
+        assert!(tab.set_title("Codex", TabTitleSource::User));
+    }
+
+    #[test]
+    fn titles_are_stored_trimmed() {
+        let mut tab = tab("");
+        assert!(tab.set_title("  fix the flaky test \n", TabTitleSource::User));
+        assert_eq!(tab.title(), "fix the flaky test");
+    }
+
+    /// Reset name reopens auto-naming and keeps the text, so the row does not
+    /// blink back to its positional fallback while waiting for the next turn.
+    #[test]
+    fn unlock_title_reopens_auto_naming_and_keeps_the_text() {
+        let mut tab = tab("Claude Code");
+        assert!(tab.set_title("sprint 3", TabTitleSource::User));
+
+        assert!(tab.unlock_title());
+        assert_eq!(tab.title(), "sprint 3");
+        assert!(!tab.title_is_user_owned());
+        assert!(tab.set_title("wire up the parser", TabTitleSource::Auto));
+        assert_eq!(tab.title(), "wire up the parser");
+    }
+
+    #[test]
+    fn unlock_title_on_an_already_automatic_tab_reports_no_change() {
+        let mut tab = tab("Claude Code");
+        assert!(!tab.unlock_title());
+    }
+
+    /// A blank rename is the inline editor being dismissed, not a request to
+    /// erase the name - `commit_rename` guards this too, doubly on purpose.
+    #[test]
+    fn a_blank_user_title_is_refused() {
+        let mut tab = tab("Codex");
+        assert!(!tab.set_title("  ", TabTitleSource::User));
+        assert_eq!(tab.title(), "Codex");
+        assert!(!tab.title_is_user_owned());
+    }
+
+    #[test]
+    fn a_freshly_built_tab_is_app_named() {
+        assert!(!tab("Claude Code").title_is_user_owned());
+        assert!(!Tab::empty().title_is_user_owned());
+        assert!(Tab::restored("sprint 3", TabTitleSource::User, None).title_is_user_owned());
     }
 }

--- a/src-app/src/workspace/tab.rs
+++ b/src-app/src/workspace/tab.rs
@@ -46,16 +46,17 @@ pub struct Tab {
 impl Tab {
     /// Create a tab holding `root`, with a freshly allocated id.
     ///
-    /// The title is [`TabTitleSource::Auto`]: every in-process construction
-    /// site is Paneflow naming the tab itself (a preset label, the palette
-    /// placeholder, an empty string). A human's title only ever arrives
-    /// through [`Self::set_title`], or from the restore path via
-    /// [`Self::restored`].
+    /// The title is [`TabTitleSource::Preset`], the weakest rank: every
+    /// in-process construction site is Paneflow naming the tab itself (a
+    /// preset label, the palette placeholder, an empty string), and all of it
+    /// is meant to be replaced by a name that describes the work. A human's
+    /// title only ever arrives through [`Self::set_title`], or from the
+    /// restore path via [`Self::restored`].
     pub fn new(title: impl Into<String>, root: Option<LayoutTree>) -> Self {
         Self {
             id: next_tab_id(),
             title: title.into(),
-            title_source: TabTitleSource::Auto,
+            title_source: TabTitleSource::Preset,
             root,
             saved_layout: None,
         }
@@ -99,25 +100,28 @@ impl Tab {
         self.title_source == TabTitleSource::User
     }
 
+    /// Whether an automatic name should still be looked for. See
+    /// [`TabTitleSource::is_settled`].
+    pub fn title_is_settled(&self) -> bool {
+        self.title_source.is_settled()
+    }
+
     /// The single write path for a tab title. Returns whether anything
     /// changed, so callers persist the session only on a real delta.
     ///
     /// Rules, in order:
-    /// 1. An automatic title never overwrites a user's. This is the whole
-    ///    point of the type, and it is checked here rather than at each call
-    ///    site so no future caller can forget it.
-    /// 2. An automatic title never *clears* one. A summarizer that returns
-    ///    nothing must leave the tab as it is, not blank it.
-    /// 3. Titles are stored trimmed, and a no-op write reports `false` -
-    ///    every turn of an agent would otherwise schedule a session save that
-    ///    writes the same bytes.
+    /// 1. Precedence is [`TabTitleSource::yields_to`]'s to decide, and only
+    ///    its. Checking it here rather than at each call site is what keeps
+    ///    "a name a human typed is never overwritten" true of code not yet
+    ///    written.
+    /// 2. An automatic title never *clears* one. A CLI that generated nothing
+    ///    must leave the tab as it is, not blank it.
+    /// 3. Titles are stored trimmed, and a write that changes nothing reports
+    ///    `false` - every turn of an agent would otherwise schedule a session
+    ///    save of identical bytes.
     pub fn set_title(&mut self, title: &str, source: TabTitleSource) -> bool {
         let title = title.trim();
-        if source != TabTitleSource::User {
-            if self.title_is_user_owned() || title.is_empty() {
-                return false;
-            }
-        } else if title.is_empty() {
+        if title.is_empty() || !self.title_source.yields_to(source) {
             return false;
         }
         if self.title == title && self.title_source == source {
@@ -129,16 +133,18 @@ impl Tab {
         true
     }
 
-    /// Hand a user-owned title back to auto-naming (the tab menu's "Reset
-    /// name"). Returns whether anything changed.
+    /// Hand a named tab back to auto-naming (the tab menu's "Reset name").
+    /// Returns whether anything changed.
     ///
     /// The text is deliberately kept: dropping it would flash the tab back to
     /// its "Tab 3" fallback until the next turn produced a name. Only the
-    /// ownership changes, so the next automatic title may take over.
+    /// ownership changes - and it drops all the way to `Preset`, so the very
+    /// next thing the agent does can name the tab, rather than the reset only
+    /// taking effect once a *better* rank comes along.
     pub fn unlock_title(&mut self) -> bool {
-        let was_locked = self.title_is_user_owned();
-        self.title_source = TabTitleSource::Auto;
-        was_locked
+        let changed = self.title_source != TabTitleSource::Preset;
+        self.title_source = TabTitleSource::Preset;
+        changed
     }
 
     pub fn is_zoomed(&self) -> bool {
@@ -236,7 +242,7 @@ impl Tab {
     }
 }
 
-/// The title-ownership rule, tested at the one place that enforces it.
+/// The title-precedence rule, tested at the one place that enforces it.
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -245,13 +251,22 @@ mod tests {
         Tab::new(title, None)
     }
 
+    /// The ladder each rank climbs: a preset label gives way to the first
+    /// prompt's placeholder, which gives way to the title the CLI generates,
+    /// which gives way to a human.
     #[test]
-    fn auto_titles_replace_each_other() {
+    fn each_rank_replaces_the_ones_below_it() {
         let mut tab = tab("Claude Code");
-        assert!(tab.set_title("wire up the parser", TabTitleSource::Auto));
-        assert_eq!(tab.title(), "wire up the parser");
-        assert!(tab.set_title("rewrite the lexer", TabTitleSource::Auto));
-        assert_eq!(tab.title(), "rewrite the lexer");
+        assert_eq!(tab.title_source(), TabTitleSource::Preset);
+
+        assert!(tab.set_title("fix the flaky worktree test", TabTitleSource::Prompt));
+        assert_eq!(tab.title(), "fix the flaky worktree test");
+
+        assert!(tab.set_title("Worktree test deflake", TabTitleSource::Generated));
+        assert_eq!(tab.title(), "Worktree test deflake");
+
+        assert!(tab.set_title("sprint 3", TabTitleSource::User));
+        assert_eq!(tab.title(), "sprint 3");
     }
 
     #[test]
@@ -259,9 +274,38 @@ mod tests {
         let mut tab = tab("Claude Code");
         assert!(tab.set_title("sprint 3", TabTitleSource::User));
 
-        assert!(!tab.set_title("wire up the parser", TabTitleSource::Auto));
+        for source in [
+            TabTitleSource::Preset,
+            TabTitleSource::Prompt,
+            TabTitleSource::Generated,
+        ] {
+            assert!(!tab.set_title("something else", source), "{source:?}");
+        }
         assert_eq!(tab.title(), "sprint 3");
         assert!(tab.title_is_user_owned());
+    }
+
+    /// The bug this ranking exists for: a session is torn down a few seconds
+    /// after each turn, so every new turn used to look like a first one and
+    /// rename the tab after whatever was just typed. A tab keeps naming the
+    /// work it was opened for.
+    #[test]
+    fn a_later_prompt_does_not_replace_the_first_ones_placeholder() {
+        let mut tab = tab("Claude Code");
+        assert!(tab.set_title("fix the flaky worktree test", TabTitleSource::Prompt));
+
+        assert!(!tab.set_title("yes go ahead", TabTitleSource::Prompt));
+        assert_eq!(tab.title(), "fix the flaky worktree test");
+    }
+
+    /// A generated title is live intent, not a one-shot: a CLI that
+    /// regenerates its session title has a better one.
+    #[test]
+    fn a_generated_title_replaces_an_earlier_generated_title() {
+        let mut tab = tab("Claude Code");
+        assert!(tab.set_title("Worktree test deflake", TabTitleSource::Generated));
+        assert!(tab.set_title("Release checksum job", TabTitleSource::Generated));
+        assert_eq!(tab.title(), "Release checksum job");
     }
 
     #[test]
@@ -272,24 +316,34 @@ mod tests {
         assert_eq!(tab.title(), "sprint 4");
     }
 
-    /// A summarizer that returns nothing must leave the tab alone rather than
-    /// blank it - the sidebar would fall back to "Tab 2" out of nowhere.
+    /// A preset label never replaces one: the empty tab being filled already
+    /// carries whatever it should.
+    #[test]
+    fn a_preset_label_does_not_replace_a_preset_label() {
+        let mut tab = tab("Claude Code");
+        assert!(!tab.set_title("Codex", TabTitleSource::Preset));
+        assert_eq!(tab.title(), "Claude Code");
+    }
+
+    /// A CLI that generated nothing must leave the tab alone rather than blank
+    /// it - the sidebar would fall back to "Tab 2" out of nowhere.
     #[test]
     fn an_automatic_title_never_clears_one() {
         let mut tab = tab("OpenCode");
-        assert!(!tab.set_title("", TabTitleSource::Auto));
-        assert!(!tab.set_title("   \n ", TabTitleSource::Auto));
+        assert!(!tab.set_title("", TabTitleSource::Generated));
+        assert!(!tab.set_title("   \n ", TabTitleSource::Prompt));
         assert_eq!(tab.title(), "OpenCode");
     }
 
-    /// Every agent turn would otherwise schedule a session write of identical
-    /// bytes.
+    /// Every turn of an agent would otherwise schedule a session write of
+    /// identical bytes.
     #[test]
     fn an_unchanged_title_reports_no_change() {
         let mut tab = tab("Codex");
-        assert!(!tab.set_title("Codex", TabTitleSource::Auto));
-        assert!(!tab.set_title("  Codex  ", TabTitleSource::Auto));
-        assert!(tab.set_title("Codex", TabTitleSource::User));
+        assert!(tab.set_title("Deflake the tests", TabTitleSource::Generated));
+        assert!(!tab.set_title("Deflake the tests", TabTitleSource::Generated));
+        assert!(!tab.set_title("  Deflake the tests  ", TabTitleSource::Generated));
+        assert!(tab.set_title("Deflake the tests", TabTitleSource::User));
     }
 
     #[test]
@@ -299,24 +353,43 @@ mod tests {
         assert_eq!(tab.title(), "fix the flaky test");
     }
 
-    /// Reset name reopens auto-naming and keeps the text, so the row does not
-    /// blink back to its positional fallback while waiting for the next turn.
+    /// Only the top two ranks stop the search for a better name. A tab still
+    /// wearing a preset label or a placeholder is one worth reading a
+    /// transcript for.
     #[test]
-    fn unlock_title_reopens_auto_naming_and_keeps_the_text() {
+    fn only_a_generated_or_user_title_settles_a_tab() {
+        let mut tab = tab("Claude Code");
+        assert!(!tab.title_is_settled());
+
+        assert!(tab.set_title("fix the flaky test", TabTitleSource::Prompt));
+        assert!(!tab.title_is_settled());
+
+        assert!(tab.set_title("Test deflake", TabTitleSource::Generated));
+        assert!(tab.title_is_settled());
+
+        assert!(tab.set_title("sprint 3", TabTitleSource::User));
+        assert!(tab.title_is_settled());
+    }
+
+    /// Reset name drops all the way to the weakest rank, so the very next
+    /// thing the agent does can name the tab. Dropping only one rank would
+    /// leave a reset tab waiting on a title better than the one it had.
+    #[test]
+    fn unlock_title_reopens_naming_and_keeps_the_text() {
         let mut tab = tab("Claude Code");
         assert!(tab.set_title("sprint 3", TabTitleSource::User));
 
         assert!(tab.unlock_title());
         assert_eq!(tab.title(), "sprint 3");
         assert!(!tab.title_is_user_owned());
-        assert!(tab.set_title("wire up the parser", TabTitleSource::Auto));
-        assert_eq!(tab.title(), "wire up the parser");
+        assert!(!tab.title_is_settled());
+        assert!(tab.set_title("fix the flaky test", TabTitleSource::Prompt));
+        assert_eq!(tab.title(), "fix the flaky test");
     }
 
     #[test]
-    fn unlock_title_on_an_already_automatic_tab_reports_no_change() {
-        let mut tab = tab("Claude Code");
-        assert!(!tab.unlock_title());
+    fn unlock_title_on_a_preset_named_tab_reports_no_change() {
+        assert!(!tab("Claude Code").unlock_title());
     }
 
     /// A blank rename is the inline editor being dismissed, not a request to


### PR DESCRIPTION
## What changes for the user

Four agents launched from the preset picker used to give four sidebar rows all
reading "Claude Code", and the only way to tell them apart was to open each
one. A tab now names itself after the work going on inside it.

Naming happens in two takes, because the good name does not exist when the tab
most needs one:

1. **Placeholder, instantly.** The opening words of the first prompt sent to
   the agent, taken from the hook frame that already reports it.
2. **The real title, a turn later.** The title the agent's own CLI generated
   for its resume picker. Claude Code writes a `type:"ai-title"` record into
   the transcript the stop hook points at, and `claude_sessions.rs` already
   knew how to read it.

No model of our own is called at any point, so naming cannot be slow, cost
anything, or be unavailable.

**A name you type is yours.** Renaming a tab turns automatic naming off for
that tab for good. "Reset name", in the tab's context menu, hands it back and
keeps the visible text so the row does not blink to its "Tab 3" fallback.

**Workspaces can no longer be renamed.** A workspace is named after the folder
it holds, and a title free to drift from that folder left the sidebar claiming
a name nothing on disk answered to, with no way back. Double-clicking a folder
row now just selects it.

## How it holds together

`TabTitleSource` is a strict ladder, `Preset < Prompt < Generated < User`. A
title yields only to a strictly higher rank, plus - for the top two, which
describe live intent - to another of its own kind. That single rule carries
every guarantee the feature makes:

- a human's name is never overwritten by anything automatic;
- a regenerated session title replaces an earlier one;
- the second prompt of a session cannot rename the tab away from the work it
  was opened for;
- a preset label is the weakest of all, which is the point.

`Tab::set_title` is the only write path and `Tab::title` is private, so the
rule is enforced in one place rather than trusted to every caller. Ownership
lives on the tab, not on the agent session: sessions are torn down five seconds
after each turn ends, and state kept there reset every turn - which let each
new prompt rename the tab. That was a real bug during development, and the
ladder is what fixes it.

A tab shared by several terminals is never named: no single agent speaks for
it.

## Compatibility

`TabSession::title_source` is an `Option`. A file that states its provenance is
believed as written, so a tab someone deliberately renamed "Claude Code" keeps
its lock. A file written before this feature says nothing, and its titles are
two different things wearing the same clothes - names people typed, and preset
labels. Those are judged by content exactly once, on restore: blank titles,
agent display names, the shell and palette placeholders, and the workspace's
own command buttons go back to `Preset`; everything else stays `User`. The
asymmetry is deliberate - a wrong lock costs one rename, a wrong unlock
destroys a name with no undo.

## Per-agent reach

| Agent | Placeholder | Generated title |
|---|---|---|
| Claude Code | yes | yes (`ai-title` in the transcript) |
| Codex | yes | none written by the CLI |
| Pi | yes | none written by the CLI |
| OpenCode | yes | exists, but behind an `opencode session list` subprocess rather than a file the hook points at - wiring that up is a separate decision about spawning a process per turn |
| Others | only if their hook payload names the field `prompt` | not investigated |

`generated_title_source` is the single place that says which agent has a title
and where it lives.

## Hook payload change

`ai.prompt_submit` now carries the opening 512 bytes of the `prompt` field.
That arm of `compact_hook_payload` was deliberately empty, with a test naming
the omission, so this is a considered change rather than an oversight: the
socket is peer-UID-gated, and the app already reads whole transcripts on
`ai.stop`, so it had access to prompts by another route. The cap is far tighter
than the 4 KiB the other text fields get - everything past the first sentence
would cross the socket on every prompt for nothing. The text is untrusted and
reaches a label, so it goes through `clean_sidebar_title` like every other
CLI-written title. `docs/hooks.md` documents the new contract.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` - 2210 tests, 0 failures
- Manual pass on Linux/Wayland by the author: tabs named from the first prompt,
  then replaced by Claude Code's generated title.

Not verified: macOS and Windows, by inspection only - nothing here is
platform-gated, but no run happened on either.
