### PR TITLE
feat(settings): group and search the keyboard shortcuts page

### DIFF
--- a/src-app/assets/icons/keyboard.svg
+++ b/src-app/assets/icons/keyboard.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M2 6m0 2a2 2 0 0 1 2 -2h16a2 2 0 0 1 2 2v8a2 2 0 0 1 -2 2h-16a2 2 0 0 1 -2 -2z"/>
+  <path d="M6 10l0 .01"/>
+  <path d="M10 10l0 .01"/>
+  <path d="M14 10l0 .01"/>
+  <path d="M18 10l0 .01"/>
+  <path d="M6 14l12 0"/>
+</svg>

--- a/src-app/src/app/bootstrap.rs
+++ b/src-app/src/app/bootstrap.rs
@@ -843,6 +843,7 @@ impl PaneFlowApp {
             recording_shortcut_idx: None,
             shortcut_search_input,
             shortcut_capture_active: false,
+            shortcut_reset_pending: false,
             collapsed_shortcut_groups: std::collections::HashSet::new(),
             settings_focus: cx.focus_handle(),
             mono_font_names: Vec::new(),

--- a/src-app/src/app/bootstrap.rs
+++ b/src-app/src/app/bootstrap.rs
@@ -751,6 +751,13 @@ impl PaneFlowApp {
             cx.new(|cx| crate::widgets::text_input::TextInput::new("", "Search settings…", cx));
         cx.observe(&settings_search_input, |_, _, cx| cx.notify())
             .detach();
+        // Shortcuts-page filter. Same recipe: a real TextInput, observed so
+        // every keystroke re-renders the page and re-filters the sections.
+        let shortcut_search_input = cx.new(|cx| {
+            crate::widgets::text_input::TextInput::new("", "Search actions or keys…", cx)
+        });
+        cx.observe(&shortcut_search_input, |_, _, cx| cx.notify())
+            .detach();
         let workspace_template_name_input =
             cx.new(|cx| crate::widgets::text_input::TextInput::new("", "Workspace name", cx));
         cx.observe(&workspace_template_name_input, |_, _, cx| cx.notify())
@@ -834,6 +841,10 @@ impl PaneFlowApp {
             sidebar_scroll: gpui::ScrollHandle::new(),
             effective_shortcuts,
             recording_shortcut_idx: None,
+            shortcut_search_input,
+            shortcut_captured_key: None,
+            shortcut_capture_active: false,
+            collapsed_shortcut_groups: std::collections::HashSet::new(),
             settings_focus: cx.focus_handle(),
             mono_font_names: Vec::new(),
             font_dropdown_open: false,

--- a/src-app/src/app/bootstrap.rs
+++ b/src-app/src/app/bootstrap.rs
@@ -842,7 +842,6 @@ impl PaneFlowApp {
             effective_shortcuts,
             recording_shortcut_idx: None,
             shortcut_search_input,
-            shortcut_captured_key: None,
             shortcut_capture_active: false,
             collapsed_shortcut_groups: std::collections::HashSet::new(),
             settings_focus: cx.focus_handle(),

--- a/src-app/src/app/settings.rs
+++ b/src-app/src/app/settings.rs
@@ -60,28 +60,20 @@ impl PaneFlowApp {
 
     /// Arm or disarm the Shortcuts page's key-capture mode.
     ///
-    /// Disarming always drops the captured chord: leaving the mode with a
-    /// filter still applied would strand the user on a filtered list whose
-    /// cause is no longer visible on screen.
+    /// Arming clears the field so the next chord lands in an empty box; the
+    /// captured chord is then just the field's value, which keeps a single
+    /// visible filter state instead of a hidden second one.
     pub(crate) fn set_shortcut_capture(&mut self, active: bool, cx: &mut Context<Self>) {
         self.shortcut_capture_active = active;
-        if !active {
-            self.shortcut_captured_key = None;
-        }
-        // A capture and a text query are two ways to ask the same question, so
-        // arming one clears the other rather than intersecting them.
-        if active {
-            self.shortcut_search_input.update(cx, |input, cx| {
-                input.set_value("", cx);
-            });
-        }
+        self.shortcut_search_input.update(cx, |input, cx| {
+            input.set_value("", cx);
+        });
         self.recording_shortcut_idx = None;
     }
 
-    /// Clear every Shortcuts-page filter (text query and captured chord).
+    /// Clear the Shortcuts-page filter and leave capture mode.
     pub(crate) fn clear_shortcut_filters(&mut self, cx: &mut Context<Self>) {
         self.shortcut_capture_active = false;
-        self.shortcut_captured_key = None;
         self.shortcut_search_input.update(cx, |input, cx| {
             input.set_value("", cx);
         });
@@ -221,7 +213,7 @@ impl PaneFlowApp {
     pub(crate) fn handle_settings_key_down(
         &mut self,
         event: &KeyDownEvent,
-        window: &mut Window,
+        _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         // Font dropdown typeahead (Terminal page).
@@ -251,29 +243,10 @@ impl PaneFlowApp {
             return;
         }
 
-        // Shortcuts-page key capture: the pressed chord becomes the filter
-        // rather than a rebind. Checked before the Escape branch below so
-        // Escape leaves capture mode instead of closing the whole modal - a
-        // user who armed capture expects Escape to disarm it first.
-        if self.shortcut_capture_active && self.recording_shortcut_idx.is_none() {
-            if event.keystroke.key == "escape" {
-                self.set_shortcut_capture(false, cx);
-                cx.notify();
-                return;
-            }
-            // Bare modifiers are held on the way to a real chord, not a chord.
-            if keybindings::is_bare_modifier(&event.keystroke) {
-                return;
-            }
-            self.shortcut_captured_key =
-                Some(keybindings::format_keystroke(&event.keystroke.to_string()));
-            cx.notify();
-            return;
-        }
-
-        // Escape (outside active shortcut recording): close an open Terminal-page
-        // dropdown first, otherwise leave settings. During recording, Escape
-        // falls through to `handle_shortcut_recording`, which cancels capture.
+        // Escape: close an open Terminal-page dropdown first, otherwise leave
+        // settings. Escape during shortcut recording or key capture never gets
+        // here - `intercept_shortcut_keystroke` consumes it upstream, before
+        // GPUI matches any binding.
         if event.keystroke.key == "escape" && self.recording_shortcut_idx.is_none() {
             if self.terminal_dropdown.is_some() {
                 self.terminal_dropdown = None;
@@ -285,18 +258,66 @@ impl PaneFlowApp {
                 self.close_settings(cx);
             }
             cx.notify();
-            return;
+        }
+    }
+
+    /// App-wide keystroke interceptor for the Shortcuts settings page.
+    ///
+    /// Registered through `App::intercept_keystrokes`, which is the *only*
+    /// hook that runs before GPUI matches a key binding. A `on_key_down` (or
+    /// even `capture_key_down`) listener is too late: when a binding matches
+    /// and its action is handled, `dispatch_key_event` returns without ever
+    /// calling `finish_dispatch_key_event`, so no key listener fires at all.
+    /// That is why pressing Cmd+Q to search for - or rebind - the Quit
+    /// shortcut used to quit the app instead.
+    ///
+    /// Returns `true` when the chord was consumed, in which case the caller
+    /// must call `cx.stop_propagation()` to suppress the action.
+    pub(crate) fn intercept_shortcut_keystroke(
+        &mut self,
+        keystroke: &gpui::Keystroke,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if self.settings_section != Some(SettingsSection::Shortcuts) {
+            return false;
+        }
+        // Modifiers held on the way to a real chord are not a chord.
+        if keybindings::is_bare_modifier(keystroke) {
+            return false;
         }
 
-        // Shortcut recording (only on the Shortcuts page).
-        if self.settings_section == Some(SettingsSection::Shortcuts) {
-            self.handle_shortcut_recording(event, window, cx);
+        // Rebind recording takes precedence: the row is already armed.
+        if self.recording_shortcut_idx.is_some() {
+            self.handle_shortcut_recording(keystroke, window, cx);
+            cx.notify();
+            return true;
         }
+
+        if !self.shortcut_capture_active {
+            return false;
+        }
+
+        if keystroke.key == "escape" {
+            self.set_shortcut_capture(false, cx);
+            cx.notify();
+            return true;
+        }
+
+        // The chord goes straight into the search field: seeing what was
+        // pressed is the whole point, and it keeps one visible filter state
+        // rather than a hidden second one.
+        let formatted = keybindings::format_keystroke(&keystroke.to_string());
+        self.shortcut_search_input.update(cx, |input, cx| {
+            input.set_value(formatted, cx);
+        });
+        cx.notify();
+        true
     }
 
     pub(crate) fn handle_shortcut_recording(
         &mut self,
-        event: &KeyDownEvent,
+        keystroke: &gpui::Keystroke,
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -305,12 +326,12 @@ impl PaneFlowApp {
         };
 
         // Ignore bare modifier presses (Shift alone, Ctrl alone, etc.)
-        if keybindings::is_bare_modifier(&event.keystroke) {
+        if keybindings::is_bare_modifier(keystroke) {
             return;
         }
 
         // Escape cancels recording.
-        if event.keystroke.key == "escape" {
+        if keystroke.key == "escape" {
             self.recording_shortcut_idx = None;
             cx.notify();
             return;
@@ -327,7 +348,7 @@ impl PaneFlowApp {
         };
 
         // Format keystroke to a GPUI string (e.g. "ctrl-shift-d") and save it.
-        let new_key = event.keystroke.to_string();
+        let new_key = keystroke.to_string();
         if !config_writer::save_shortcut_checked(&new_key, action_name) {
             self.recording_shortcut_idx = None;
             self.show_toast("Could not save shortcut", cx);

--- a/src-app/src/app/settings.rs
+++ b/src-app/src/app/settings.rs
@@ -63,19 +63,27 @@ impl PaneFlowApp {
     /// Arming clears the field so the next chord lands in an empty box; the
     /// captured chord is then just the field's value, which keeps a single
     /// visible filter state instead of a hidden second one.
+    ///
+    /// Disarming deliberately leaves the field alone. Clicking a row to rebind
+    /// disarms capture, and wiping the query there would drop the filter that
+    /// put the row on screen - re-collapsing its section and scrolling the
+    /// now-armed row out of sight.
     pub(crate) fn set_shortcut_capture(&mut self, active: bool, cx: &mut Context<Self>) {
         self.shortcut_capture_active = active;
-        self.shortcut_search_input.update(cx, |input, cx| {
-            input.set_value("", cx);
-        });
-        self.recording_shortcut_idx = None;
+        if active {
+            self.shortcut_search_input.update(cx, |input, cx| {
+                input.clear(cx);
+            });
+            self.recording_shortcut_idx = None;
+        }
     }
 
-    /// Clear the Shortcuts-page filter and leave capture mode.
+    /// Clear the Shortcuts-page filter and leave capture mode. The explicit
+    /// "start over" action, unlike [`Self::set_shortcut_capture`].
     pub(crate) fn clear_shortcut_filters(&mut self, cx: &mut Context<Self>) {
         self.shortcut_capture_active = false;
         self.shortcut_search_input.update(cx, |input, cx| {
-            input.set_value("", cx);
+            input.clear(cx);
         });
     }
 
@@ -308,7 +316,9 @@ impl PaneFlowApp {
         // The chord goes straight into the search field: seeing what was
         // pressed is the whole point, and it keeps one visible filter state
         // rather than a hidden second one.
-        let formatted = keybindings::format_keystroke(&keystroke.to_string());
+        // Same reason: format_keystroke expects the `-`-separated spelling, and
+        // double-formatting a glyph string leaves it unmatchable.
+        let formatted = keybindings::format_keystroke(&keystroke.unparse());
         self.shortcut_search_input.update(cx, |input, cx| {
             input.set_value(formatted, cx);
         });
@@ -348,8 +358,11 @@ impl PaneFlowApp {
             return;
         };
 
-        // Format keystroke to a GPUI string (e.g. "ctrl-shift-d") and save it.
-        let new_key = keystroke.to_string();
+        // `unparse` is the parseable form (`cmd-shift-d`). `to_string` is the
+        // Display impl - Apple glyphs on macOS, `❖` for Super on Linux - which
+        // `Keystroke::parse` cannot read back. Saving that wrote a chord no
+        // keypress could ever match while displacing the original default.
+        let new_key = keystroke.unparse();
         if !config_writer::save_shortcut_checked(&new_key, action_name) {
             self.recording_shortcut_idx = None;
             self.show_toast("Could not save shortcut", cx);

--- a/src-app/src/app/settings.rs
+++ b/src-app/src/app/settings.rs
@@ -58,9 +58,40 @@ impl PaneFlowApp {
         cx.notify();
     }
 
+    /// Arm or disarm the Shortcuts page's key-capture mode.
+    ///
+    /// Disarming always drops the captured chord: leaving the mode with a
+    /// filter still applied would strand the user on a filtered list whose
+    /// cause is no longer visible on screen.
+    pub(crate) fn set_shortcut_capture(&mut self, active: bool, cx: &mut Context<Self>) {
+        self.shortcut_capture_active = active;
+        if !active {
+            self.shortcut_captured_key = None;
+        }
+        // A capture and a text query are two ways to ask the same question, so
+        // arming one clears the other rather than intersecting them.
+        if active {
+            self.shortcut_search_input.update(cx, |input, cx| {
+                input.set_value("", cx);
+            });
+        }
+        self.recording_shortcut_idx = None;
+    }
+
+    /// Clear every Shortcuts-page filter (text query and captured chord).
+    pub(crate) fn clear_shortcut_filters(&mut self, cx: &mut Context<Self>) {
+        self.shortcut_capture_active = false;
+        self.shortcut_captured_key = None;
+        self.shortcut_search_input.update(cx, |input, cx| {
+            input.set_value("", cx);
+        });
+    }
+
     pub(crate) fn close_settings(&mut self, cx: &mut Context<Self>) {
         self.settings_section = None;
         self.profile_menu_open = None;
+        self.clear_shortcut_filters(cx);
+        self.collapsed_shortcut_groups.clear();
         self.font_dropdown_open = false;
         self.font_search.clear();
         self.theme_dropdown_open = false;
@@ -217,6 +248,26 @@ impl PaneFlowApp {
                     }
                 }
             }
+            return;
+        }
+
+        // Shortcuts-page key capture: the pressed chord becomes the filter
+        // rather than a rebind. Checked before the Escape branch below so
+        // Escape leaves capture mode instead of closing the whole modal - a
+        // user who armed capture expects Escape to disarm it first.
+        if self.shortcut_capture_active && self.recording_shortcut_idx.is_none() {
+            if event.keystroke.key == "escape" {
+                self.set_shortcut_capture(false, cx);
+                cx.notify();
+                return;
+            }
+            // Bare modifiers are held on the way to a real chord, not a chord.
+            if keybindings::is_bare_modifier(&event.keystroke) {
+                return;
+            }
+            self.shortcut_captured_key =
+                Some(keybindings::format_keystroke(&event.keystroke.to_string()));
+            cx.notify();
             return;
         }
 

--- a/src-app/src/app/settings.rs
+++ b/src-app/src/app/settings.rs
@@ -84,6 +84,7 @@ impl PaneFlowApp {
         self.profile_menu_open = None;
         self.clear_shortcut_filters(cx);
         self.collapsed_shortcut_groups.clear();
+        self.shortcut_reset_pending = false;
         self.font_dropdown_open = false;
         self.font_search.clear();
         self.theme_dropdown_open = false;

--- a/src-app/src/keybindings/display.rs
+++ b/src-app/src/keybindings/display.rs
@@ -20,6 +20,11 @@ pub struct ShortcutEntry {
     /// (zero-override) case. Indexing `DEFAULTS` by row would silently rebind
     /// the *wrong* action and corrupt `paneflow.json`.
     pub action_name: &'static str,
+    /// Section this row is filed under on the Shortcuts settings page.
+    pub group: super::registry::ShortcutGroup,
+    /// Lowercase ASCII spellings of [`Self::key`], for the settings text
+    /// filter. Empty when the action is unbound. See [`ascii_key_forms`].
+    pub search_key: String,
 }
 
 /// Format a GPUI keystroke string for display.
@@ -89,6 +94,47 @@ pub fn format_keystroke(key: &str) -> String {
     }
 }
 
+/// ASCII spellings of a raw keystroke, for the Shortcuts page's text filter.
+///
+/// [`format_keystroke`] renders Apple HIG glyphs on macOS (`⌘⇧D`, no
+/// separator), so a user typing "cmd+shift" or "ctrl+shift" would match
+/// nothing there. This returns every plus-joined ASCII spelling of the chord so
+/// a substring search finds it on any platform, including both readings of
+/// GPUI's `secondary` (Cmd on macOS, Ctrl elsewhere) and the usual aliases.
+///
+/// Result is lowercase and space-separated, e.g. `secondary-shift-d` ->
+/// `"ctrl+shift+d cmd+shift+d command+shift+d"`.
+fn ascii_key_forms(raw_key: &str) -> String {
+    // Each token expands to its accepted spellings; the chord is then the
+    // cartesian product of those, which stays tiny (chords are 2-4 tokens).
+    let alternatives: Vec<Vec<&str>> = raw_key
+        .split('-')
+        .map(|part| match part {
+            "secondary" => vec!["ctrl", "cmd", "command"],
+            "cmd" | "super" | "win" => vec!["cmd", "command", "super", "win"],
+            "ctrl" => vec!["ctrl", "control"],
+            "alt" => vec!["alt", "option", "opt"],
+            other => vec![other],
+        })
+        .collect();
+
+    let mut forms: Vec<String> = vec![String::new()];
+    for options in &alternatives {
+        let mut next = Vec::with_capacity(forms.len() * options.len());
+        for prefix in &forms {
+            for option in options {
+                if prefix.is_empty() {
+                    next.push((*option).to_string());
+                } else {
+                    next.push(format!("{prefix}+{option}"));
+                }
+            }
+        }
+        forms = next;
+    }
+    forms.join(" ").to_lowercase()
+}
+
 /// Compute the effective shortcut list by merging defaults with user overrides.
 ///
 /// User overrides replace default bindings for the same action. Additional user
@@ -148,6 +194,10 @@ pub fn effective_shortcuts(user_shortcuts: &HashMap<String, String>) -> Vec<Shor
             key,
             description: meta.description.to_string(),
             action_name: meta.name,
+            group: meta.group,
+            search_key: ascii_key_forms(
+                user_by_action.get(d.action_name).copied().unwrap_or(d.key),
+            ),
         });
     }
 
@@ -163,6 +213,8 @@ pub fn effective_shortcuts(user_shortcuts: &HashMap<String, String>) -> Vec<Shor
                 key: format_keystroke(key),
                 description: meta.description.to_string(),
                 action_name: meta.name,
+                group: meta.group,
+                search_key: ascii_key_forms(key),
             });
         }
     }
@@ -173,6 +225,8 @@ pub fn effective_shortcuts(user_shortcuts: &HashMap<String, String>) -> Vec<Shor
                 key: "Unassigned".to_string(),
                 description: action_description(meta.name).to_string(),
                 action_name: meta.name,
+                group: meta.group,
+                search_key: String::new(),
             });
         }
     }
@@ -310,6 +364,69 @@ mod tests {
             .find(|e| e.action_name == "split_horizontally")
             .expect("unbound actions remain visible for rebinding");
         assert_eq!(split_h.key, "Unassigned");
+    }
+
+    #[test]
+    fn ascii_key_forms_covers_both_readings_of_secondary() {
+        // `secondary` is Cmd on macOS and Ctrl elsewhere, so both spellings
+        // must find the row whatever platform the settings page renders on.
+        let forms = ascii_key_forms("secondary-shift-d");
+        assert!(forms.contains("ctrl+shift+d"), "{forms}");
+        assert!(forms.contains("cmd+shift+d"), "{forms}");
+        assert!(forms.contains("command+shift+d"), "{forms}");
+    }
+
+    #[test]
+    fn ascii_key_forms_expands_modifier_aliases() {
+        assert!(ascii_key_forms("alt-left").contains("option+left"));
+        assert!(ascii_key_forms("ctrl-c").contains("control+c"));
+        assert!(ascii_key_forms("cmd-q").contains("super+q"));
+    }
+
+    #[test]
+    fn ascii_key_forms_is_lowercase_for_substring_matching() {
+        // The settings filter lowercases the query, so the haystack must be
+        // lowercase too or a match on an uppercase key would be missed.
+        let forms = ascii_key_forms("ctrl-shift-PageUp");
+        assert_eq!(forms, forms.to_lowercase());
+        assert!(forms.contains("pageup"), "{forms}");
+    }
+
+    #[test]
+    fn every_entry_carries_its_registry_group() {
+        // The Shortcuts page buckets by group; an entry landing in the wrong
+        // section (or a section the page never renders) would go missing.
+        let entries = effective_shortcuts(&HashMap::new());
+        for entry in &entries {
+            let meta = ACTIONS
+                .iter()
+                .find(|a| a.name == entry.action_name)
+                .expect("every entry comes from the registry");
+            assert_eq!(
+                entry.group, meta.group,
+                "{} landed in the wrong section",
+                entry.action_name
+            );
+        }
+        // Every declared section is reachable from the page.
+        for group in super::super::registry::ShortcutGroup::ALL {
+            assert!(
+                entries.iter().any(|e| e.group == *group),
+                "{group:?} has no rows, so its header would render empty"
+            );
+        }
+    }
+
+    #[test]
+    fn bound_entries_have_a_searchable_ascii_key() {
+        let entries = effective_shortcuts(&HashMap::new());
+        for entry in entries.iter().filter(|e| e.key != "Unassigned") {
+            assert!(
+                !entry.search_key.is_empty(),
+                "{} is bound but not findable by key",
+                entry.action_name
+            );
+        }
     }
 
     #[cfg(not(target_os = "macos"))]

--- a/src-app/src/keybindings/display.rs
+++ b/src-app/src/keybindings/display.rs
@@ -105,10 +105,23 @@ pub fn format_keystroke(key: &str) -> String {
 /// Result is lowercase and space-separated, e.g. `secondary-shift-d` ->
 /// `"ctrl+shift+d cmd+shift+d command+shift+d"`.
 fn ascii_key_forms(raw_key: &str) -> String {
+    // The key itself can be `-` (font_size_decrease is `secondary--`), so the
+    // final separator is split off explicitly instead of letting `split('-')`
+    // turn the chord into empty tokens.
+    let (modifier_part, key) = match raw_key.strip_suffix("--") {
+        Some(modifiers) => (modifiers, "-"),
+        None => match raw_key.rsplit_once('-') {
+            Some((modifiers, key)) => (modifiers, key),
+            None => ("", raw_key),
+        },
+    };
+
     // Each token expands to its accepted spellings; the chord is then the
     // cartesian product of those, which stays tiny (chords are 2-4 tokens).
-    let alternatives: Vec<Vec<&str>> = raw_key
+    let alternatives: Vec<Vec<&str>> = modifier_part
         .split('-')
+        .filter(|part| !part.is_empty())
+        .chain(std::iter::once(key))
         .map(|part| match part {
             "secondary" => vec!["ctrl", "cmd", "command"],
             "cmd" | "super" | "win" => vec!["cmd", "command", "super", "win"],
@@ -194,19 +207,25 @@ pub fn effective_shortcuts(user_shortcuts: &HashMap<String, String>) -> Vec<Shor
             continue;
         }
 
-        // Prefer the platform-native chord when this action has one.
-        let default_key = macos_key_by_action
-            .get(d.action_name)
-            .copied()
-            .unwrap_or(d.key);
+        // Prefer the platform-native chord, but only while it is still live:
+        // if the user unbound or reassigned cmd-c, copy is still on
+        // ctrl-shift-c and the row must say so rather than claim the chord it
+        // no longer owns.
+        let default_key = match macos_key_by_action.get(d.action_name).copied() {
+            Some(native) if !is_unbound(native) && !is_user_claimed(native) => native,
+            _ => d.key,
+        };
 
         // If user overrode this action to a different key, show that key. If a
         // different action claimed this default chord, mirror apply_keybindings
         // and hide the displaced default row until it is explicitly rebound.
+        // The displacement test is on `d.key` - the binding this iteration
+        // represents - so a dead native chord cannot suppress a live generic
+        // one and leave the action reading "Unassigned" while it still works.
         let key = if let Some(user_key) = user_by_action.get(d.action_name) {
             format_keystroke(user_key)
         } else {
-            if is_unbound(default_key) || is_user_claimed(default_key) {
+            if is_unbound(d.key) || is_user_claimed(d.key) {
                 continue;
             }
             format_keystroke(default_key)
@@ -390,6 +409,40 @@ mod tests {
             .find(|e| e.action_name == "split_horizontally")
             .expect("unbound actions remain visible for rebinding");
         assert_eq!(split_h.key, "Unassigned");
+    }
+
+    #[test]
+    fn ascii_key_forms_handles_a_minus_key() {
+        // font_size_decrease is `secondary--`: the key itself is `-`. Splitting
+        // naively produced empty tokens and spellings like "ctrl++".
+        let forms = ascii_key_forms("secondary--");
+        assert!(forms.contains("ctrl+-"), "{forms}");
+        assert!(forms.contains("cmd+-"), "{forms}");
+        assert!(!forms.contains("++"), "{forms}");
+    }
+
+    #[test]
+    fn every_default_chord_round_trips_through_parse() {
+        // A saved chord has to be readable by `Keystroke::parse`, which is what
+        // the keymap uses. `Keystroke::to_string` is the *display* impl (Apple
+        // glyphs on macOS) and does not round-trip; `unparse` does. This pins
+        // the property the rebind path depends on.
+        for d in DEFAULTS.iter().chain(MACOS_ONLY_DEFAULTS.iter()) {
+            let parsed = Keystroke::parse(d.key)
+                .unwrap_or_else(|_| panic!("default chord {} does not parse", d.key));
+            let round_tripped = Keystroke::parse(&parsed.unparse())
+                .unwrap_or_else(|_| panic!("unparse of {} does not re-parse", d.key));
+            assert_eq!(
+                round_tripped.key, parsed.key,
+                "{} lost its key through unparse",
+                d.key
+            );
+            assert_eq!(
+                round_tripped.modifiers, parsed.modifiers,
+                "{} lost its modifiers through unparse",
+                d.key
+            );
+        }
     }
 
     #[test]

--- a/src-app/src/keybindings/display.rs
+++ b/src-app/src/keybindings/display.rs
@@ -169,6 +169,15 @@ pub fn effective_shortcuts(user_shortcuts: &HashMap<String, String>) -> Vec<Shor
     let mut entries = Vec::new();
     let mut seen_actions: HashSet<&'static str> = HashSet::new();
 
+    // On macOS an action can be bound twice - once generically in `DEFAULTS`
+    // and once platform-natively in `MACOS_ONLY_DEFAULTS` (copy is both
+    // ctrl-shift-c and cmd-c). The settings page shows the platform-native
+    // chord for those, matching the menu bar and what a Mac user reaches for.
+    let macos_key_by_action: HashMap<&str, &str> = MACOS_ONLY_DEFAULTS
+        .iter()
+        .map(|d| (d.action_name, d.key))
+        .collect();
+
     // Defaults first, with user overrides applied. US-010: include the
     // macOS-only defaults so the settings page reflects cmd-c/cmd-v on
     // macOS (and stays unchanged on Linux where MACOS_ONLY_DEFAULTS is empty).
@@ -177,16 +186,30 @@ pub fn effective_shortcuts(user_shortcuts: &HashMap<String, String>) -> Vec<Shor
             continue;
         };
 
+        // One row per *action*, not per binding. A rebind is keyed by action
+        // name, so a second row for the same action would be a duplicate the
+        // user cannot edit independently - editing either rewrites the same
+        // entry in paneflow.json.
+        if seen_actions.contains(meta.name) {
+            continue;
+        }
+
+        // Prefer the platform-native chord when this action has one.
+        let default_key = macos_key_by_action
+            .get(d.action_name)
+            .copied()
+            .unwrap_or(d.key);
+
         // If user overrode this action to a different key, show that key. If a
         // different action claimed this default chord, mirror apply_keybindings
         // and hide the displaced default row until it is explicitly rebound.
         let key = if let Some(user_key) = user_by_action.get(d.action_name) {
             format_keystroke(user_key)
         } else {
-            if is_unbound(d.key) || is_user_claimed(d.key) {
+            if is_unbound(default_key) || is_user_claimed(default_key) {
                 continue;
             }
-            format_keystroke(d.key)
+            format_keystroke(default_key)
         };
 
         seen_actions.insert(meta.name);
@@ -196,7 +219,10 @@ pub fn effective_shortcuts(user_shortcuts: &HashMap<String, String>) -> Vec<Shor
             action_name: meta.name,
             group: meta.group,
             search_key: ascii_key_forms(
-                user_by_action.get(d.action_name).copied().unwrap_or(d.key),
+                user_by_action
+                    .get(d.action_name)
+                    .copied()
+                    .unwrap_or(default_key),
             ),
         });
     }
@@ -390,6 +416,42 @@ mod tests {
         let forms = ascii_key_forms("ctrl-shift-PageUp");
         assert_eq!(forms, forms.to_lowercase());
         assert!(forms.contains("pageup"), "{forms}");
+    }
+
+    #[test]
+    fn the_page_lists_each_action_exactly_once() {
+        // The row count is shown to the user ("N of M"), and a rebind is keyed
+        // by action name - so a second row for one action is both a wrong
+        // count and a row the user cannot edit on its own. On macOS
+        // terminal_copy and terminal_paste are bound in DEFAULTS *and* in
+        // MACOS_ONLY_DEFAULTS, which used to emit them twice.
+        let entries = effective_shortcuts(&HashMap::new());
+        let mut seen: HashSet<&str> = HashSet::new();
+        for entry in &entries {
+            assert!(
+                seen.insert(entry.action_name),
+                "{} is listed more than once",
+                entry.action_name
+            );
+        }
+        assert_eq!(
+            entries.len(),
+            ACTIONS.len(),
+            "every registry action gets exactly one row"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_rows_show_the_platform_native_chord() {
+        // Copy is ctrl-shift-c generically and cmd-c on macOS; the row should
+        // read the one the menu bar shows.
+        let entries = effective_shortcuts(&HashMap::new());
+        let copy = entries
+            .iter()
+            .find(|e| e.action_name == "terminal_copy")
+            .expect("copy is bound");
+        assert_eq!(copy.key, format_keystroke("cmd-c"));
     }
 
     #[test]

--- a/src-app/src/keybindings/mod.rs
+++ b/src-app/src/keybindings/mod.rs
@@ -4,7 +4,9 @@
 //! `clear_key_bindings()` + `bind_keys()`.
 //!
 //! Module layout (US-022):
-//! - [`registry`] - `ActionMeta` + `ACTIONS` table (one source of truth)
+//! - [`registry`] - `ActionMeta` + `ACTIONS` table (one source of truth),
+//!   plus [`ShortcutGroup`], the section each action lands in on the
+//!   settings page
 //! - [`defaults`] - `DEFAULTS` and `MACOS_ONLY_DEFAULTS` binding tables
 //! - [`apply`] - registers bindings on the GPUI `App`
 //! - [`display`] - formats keystrokes and builds the settings shortcut list
@@ -16,3 +18,4 @@ mod registry;
 
 pub use apply::{apply_keybindings, keystrokes_conflict};
 pub use display::{ShortcutEntry, effective_shortcuts, format_keystroke, is_bare_modifier};
+pub use registry::ShortcutGroup;

--- a/src-app/src/keybindings/registry.rs
+++ b/src-app/src/keybindings/registry.rs
@@ -692,6 +692,23 @@ mod tests {
     use super::*;
 
     #[test]
+    fn every_action_group_appears_in_all() {
+        // `ShortcutGroup::ALL` is hand-maintained and is the settings page's
+        // only iteration source, so a variant tagged on actions but forgotten
+        // in `ALL` makes those rows vanish - unrebindable, with no error. A
+        // test that iterates `ALL` cannot catch that; this one starts from the
+        // actions instead.
+        for meta in ACTIONS {
+            assert!(
+                ShortcutGroup::ALL.contains(&meta.group),
+                "{:?} is missing from ShortcutGroup::ALL, so {} would never render",
+                meta.group,
+                meta.name
+            );
+        }
+    }
+
+    #[test]
     fn action_from_name_known_actions() {
         assert!(action_from_name("split_horizontally").is_some());
         assert!(action_from_name("close_pane").is_some());

--- a/src-app/src/keybindings/registry.rs
+++ b/src-app/src/keybindings/registry.rs
@@ -21,6 +21,54 @@ use crate::{
 };
 use crate::{FontSizeDecrease, FontSizeIncrease, FontSizeReset, ToggleFleetSearch};
 
+/// The section an action belongs to on the Shortcuts settings page.
+///
+/// The registry's *order* used to carry this implicitly, which meant the
+/// settings page could only ever render one flat list and any reordering of
+/// `ACTIONS` silently reshuffled the visual grouping. Declaring the section
+/// makes it survive sorting, filtering, and insertion in the middle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ShortcutGroup {
+    Panes,
+    Workspaces,
+    Tabs,
+    Terminal,
+    Search,
+    Diff,
+    Markdown,
+    Agents,
+    Application,
+}
+
+impl ShortcutGroup {
+    /// Display order on the settings page, most-used first.
+    pub const ALL: &'static [ShortcutGroup] = &[
+        ShortcutGroup::Panes,
+        ShortcutGroup::Workspaces,
+        ShortcutGroup::Tabs,
+        ShortcutGroup::Terminal,
+        ShortcutGroup::Search,
+        ShortcutGroup::Diff,
+        ShortcutGroup::Markdown,
+        ShortcutGroup::Agents,
+        ShortcutGroup::Application,
+    ];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            ShortcutGroup::Panes => "Panes & splits",
+            ShortcutGroup::Workspaces => "Workspaces",
+            ShortcutGroup::Tabs => "Tabs",
+            ShortcutGroup::Terminal => "Terminal",
+            ShortcutGroup::Search => "Search",
+            ShortcutGroup::Diff => "Git diff",
+            ShortcutGroup::Markdown => "Markdown",
+            ShortcutGroup::Agents => "Agents & cockpit",
+            ShortcutGroup::Application => "Application",
+        }
+    }
+}
+
 /// Metadata for a single dispatchable action.
 ///
 /// Empty `context` means the action is global (no `KeyBindingContextPredicate`).
@@ -31,355 +79,409 @@ pub(super) struct ActionMeta {
     pub(super) factory: fn() -> Box<dyn Action>,
     pub(super) context: &'static str,
     pub(super) description: &'static str,
+    pub(super) group: ShortcutGroup,
 }
 
 /// The one source of truth for every action dispatched by `keybindings/`.
-///
-/// Order matches the historical groupings (splits, workspaces, focus, tabs,
-/// terminal, layouts, search, scroll-backward) so the settings page preserves
-/// its visual grouping when iterating.
 pub(super) const ACTIONS: &[ActionMeta] = &[
     ActionMeta {
         name: "split_horizontally",
         factory: || Box::new(SplitHorizontally),
         context: "",
         description: "Split horizontal",
+        group: ShortcutGroup::Panes,
     },
     ActionMeta {
         name: "split_vertically",
         factory: || Box::new(SplitVertically),
         context: "",
         description: "Split vertical",
+        group: ShortcutGroup::Panes,
     },
     ActionMeta {
         name: "close_pane",
         factory: || Box::new(ClosePane),
         context: "",
         description: "Close pane",
+        group: ShortcutGroup::Panes,
     },
     ActionMeta {
         name: "new_workspace",
         factory: || Box::new(NewWorkspace),
         context: "",
         description: "New workspace",
+        group: ShortcutGroup::Workspaces,
     },
     ActionMeta {
         name: "close_workspace",
         factory: || Box::new(CloseWorkspace),
         context: "",
         description: "Close workspace",
+        group: ShortcutGroup::Workspaces,
     },
     ActionMeta {
         name: "copy_workspace_path",
         factory: || Box::new(CopyWorkspacePath),
         context: "",
         description: "Copy path",
+        group: ShortcutGroup::Workspaces,
     },
     ActionMeta {
         name: "reveal_workspace_in_file_manager",
         factory: || Box::new(RevealWorkspaceInFileManager),
         context: "",
         description: "Reveal in file manager",
+        group: ShortcutGroup::Workspaces,
     },
     ActionMeta {
         name: "open_workspace_in_zed",
         factory: || Box::new(OpenWorkspaceInZed),
         context: "",
         description: "Open in Zed",
+        group: ShortcutGroup::Workspaces,
     },
     ActionMeta {
         name: "open_workspace_in_cursor",
         factory: || Box::new(OpenWorkspaceInCursor),
         context: "",
         description: "Open in Cursor",
+        group: ShortcutGroup::Workspaces,
     },
     ActionMeta {
         name: "open_workspace_in_vscode",
         factory: || Box::new(OpenWorkspaceInVsCode),
         context: "",
         description: "Open in VS Code",
+        group: ShortcutGroup::Workspaces,
     },
     ActionMeta {
         name: "open_workspace_in_windsurf",
         factory: || Box::new(OpenWorkspaceInWindsurf),
         context: "",
         description: "Open in Windsurf",
+        group: ShortcutGroup::Workspaces,
     },
     ActionMeta {
         name: "next_workspace",
         factory: || Box::new(NextWorkspace),
         context: "",
         description: "Next workspace",
+        group: ShortcutGroup::Workspaces,
     },
     ActionMeta {
         name: "focus_left",
         factory: || Box::new(FocusLeft),
         context: "",
         description: "Focus left",
+        group: ShortcutGroup::Panes,
     },
     ActionMeta {
         name: "focus_right",
         factory: || Box::new(FocusRight),
         context: "",
         description: "Focus right",
+        group: ShortcutGroup::Panes,
     },
     ActionMeta {
         name: "focus_up",
         factory: || Box::new(FocusUp),
         context: "",
         description: "Focus up",
+        group: ShortcutGroup::Panes,
     },
     ActionMeta {
         name: "focus_down",
         factory: || Box::new(FocusDown),
         context: "",
         description: "Focus down",
+        group: ShortcutGroup::Panes,
     },
     ActionMeta {
         name: "jump_next_waiting",
         factory: || Box::new(JumpNextWaiting),
         context: "",
         description: "Jump to next waiting agent",
+        group: ShortcutGroup::Agents,
     },
     ActionMeta {
         name: "select_workspace_1",
         factory: || Box::new(SelectWorkspace1),
         context: "",
         description: "Select workspace 1",
+        group: ShortcutGroup::Workspaces,
     },
     ActionMeta {
         name: "select_workspace_2",
         factory: || Box::new(SelectWorkspace2),
         context: "",
         description: "Select workspace 2",
+        group: ShortcutGroup::Workspaces,
     },
     ActionMeta {
         name: "select_workspace_3",
         factory: || Box::new(SelectWorkspace3),
         context: "",
         description: "Select workspace 3",
+        group: ShortcutGroup::Workspaces,
     },
     ActionMeta {
         name: "select_workspace_4",
         factory: || Box::new(SelectWorkspace4),
         context: "",
         description: "Select workspace 4",
+        group: ShortcutGroup::Workspaces,
     },
     ActionMeta {
         name: "select_workspace_5",
         factory: || Box::new(SelectWorkspace5),
         context: "",
         description: "Select workspace 5",
+        group: ShortcutGroup::Workspaces,
     },
     ActionMeta {
         name: "select_workspace_6",
         factory: || Box::new(SelectWorkspace6),
         context: "",
         description: "Select workspace 6",
+        group: ShortcutGroup::Workspaces,
     },
     ActionMeta {
         name: "select_workspace_7",
         factory: || Box::new(SelectWorkspace7),
         context: "",
         description: "Select workspace 7",
+        group: ShortcutGroup::Workspaces,
     },
     ActionMeta {
         name: "select_workspace_8",
         factory: || Box::new(SelectWorkspace8),
         context: "",
         description: "Select workspace 8",
+        group: ShortcutGroup::Workspaces,
     },
     ActionMeta {
         name: "select_workspace_9",
         factory: || Box::new(SelectWorkspace9),
         context: "",
         description: "Select workspace 9",
+        group: ShortcutGroup::Workspaces,
     },
     ActionMeta {
         name: "new_tab",
         factory: || Box::new(NewTab),
         context: "",
         description: "New tab",
+        group: ShortcutGroup::Tabs,
     },
     ActionMeta {
         name: "close_tab",
         factory: || Box::new(CloseTab),
         context: "",
         description: "Close tab",
+        group: ShortcutGroup::Tabs,
     },
     ActionMeta {
         name: "next_tab",
         factory: || Box::new(NextTab),
         context: "",
         description: "Next tab",
+        group: ShortcutGroup::Tabs,
     },
     ActionMeta {
         name: "previous_tab",
         factory: || Box::new(PreviousTab),
         context: "",
         description: "Previous tab",
+        group: ShortcutGroup::Tabs,
     },
     ActionMeta {
         name: "terminal_copy",
         factory: || Box::new(TerminalCopy),
         context: "Terminal",
         description: "Copy",
+        group: ShortcutGroup::Terminal,
     },
     ActionMeta {
         name: "terminal_paste",
         factory: || Box::new(TerminalPaste),
         context: "Terminal",
         description: "Paste",
+        group: ShortcutGroup::Terminal,
     },
     ActionMeta {
         name: "scroll_page_up",
         factory: || Box::new(ScrollPageUp),
         context: "Terminal",
         description: "Scroll up",
+        group: ShortcutGroup::Terminal,
     },
     ActionMeta {
         name: "scroll_page_down",
         factory: || Box::new(ScrollPageDown),
         context: "Terminal",
         description: "Scroll down",
+        group: ShortcutGroup::Terminal,
     },
     ActionMeta {
         name: "jump_prev_prompt",
         factory: || Box::new(JumpPrevPrompt),
         context: "Terminal",
         description: "Jump to previous prompt",
+        group: ShortcutGroup::Terminal,
     },
     ActionMeta {
         name: "jump_next_prompt",
         factory: || Box::new(JumpNextPrompt),
         context: "Terminal",
         description: "Jump to next prompt",
+        group: ShortcutGroup::Terminal,
     },
     ActionMeta {
         name: "close_window",
         factory: || Box::new(CloseWindow),
         context: "",
         description: "Close window",
+        group: ShortcutGroup::Application,
     },
     ActionMeta {
         name: "toggle_zoom",
         factory: || Box::new(ToggleZoom),
         context: "",
         description: "Toggle zoom",
+        group: ShortcutGroup::Panes,
     },
     ActionMeta {
         name: "layout_even_horizontal",
         factory: || Box::new(LayoutEvenHorizontal),
         context: "",
         description: "Layout even horizontal",
+        group: ShortcutGroup::Panes,
     },
     ActionMeta {
         name: "layout_even_vertical",
         factory: || Box::new(LayoutEvenVertical),
         context: "",
         description: "Layout even vertical",
+        group: ShortcutGroup::Panes,
     },
     ActionMeta {
         name: "layout_main_vertical",
         factory: || Box::new(LayoutMainVertical),
         context: "",
         description: "Layout main vertical",
+        group: ShortcutGroup::Panes,
     },
     ActionMeta {
         name: "layout_tiled",
         factory: || Box::new(LayoutTiled),
         context: "",
         description: "Layout tiled",
+        group: ShortcutGroup::Panes,
     },
     ActionMeta {
         name: "split_equalize",
         factory: || Box::new(SplitEqualize),
         context: "",
         description: "Equalize panes",
+        group: ShortcutGroup::Panes,
     },
     ActionMeta {
         name: "swap_pane",
         factory: || Box::new(SwapPane),
         context: "",
         description: "Swap pane",
+        group: ShortcutGroup::Panes,
     },
     ActionMeta {
         name: "undo_close_pane",
         factory: || Box::new(UndoClosePane),
         context: "",
         description: "Undo close pane",
+        group: ShortcutGroup::Panes,
     },
     ActionMeta {
         name: "toggle_copy_mode",
         factory: || Box::new(ToggleCopyMode),
         context: "Terminal",
         description: "Toggle copy mode",
+        group: ShortcutGroup::Terminal,
     },
     ActionMeta {
         name: "toggle_search",
         factory: || Box::new(ToggleSearch),
         context: "Terminal",
         description: "Toggle search",
+        group: ShortcutGroup::Search,
     },
     ActionMeta {
         name: "font_size_increase",
         factory: || Box::new(FontSizeIncrease),
         context: "Terminal",
         description: "Increase pane font size",
+        group: ShortcutGroup::Terminal,
     },
     ActionMeta {
         name: "font_size_decrease",
         factory: || Box::new(FontSizeDecrease),
         context: "Terminal",
         description: "Decrease pane font size",
+        group: ShortcutGroup::Terminal,
     },
     ActionMeta {
         name: "font_size_reset",
         factory: || Box::new(FontSizeReset),
         context: "Terminal",
         description: "Reset pane font size",
+        group: ShortcutGroup::Terminal,
     },
     ActionMeta {
         name: "toggle_fleet_search",
         factory: || Box::new(ToggleFleetSearch),
         context: "Search",
         description: "Search across all panes",
+        group: ShortcutGroup::Search,
     },
     ActionMeta {
         name: "toggle_search_regex",
         factory: || Box::new(ToggleSearchRegex),
         context: "Search",
         description: "Toggle search regex",
+        group: ShortcutGroup::Search,
     },
     ActionMeta {
         name: "search_next",
         factory: || Box::new(SearchNext),
         context: "Search",
         description: "Search next",
+        group: ShortcutGroup::Search,
     },
     ActionMeta {
         name: "search_prev",
         factory: || Box::new(SearchPrev),
         context: "Search",
         description: "Search previous",
+        group: ShortcutGroup::Search,
     },
     ActionMeta {
         name: "dismiss_search",
         factory: || Box::new(DismissSearch),
         context: "Search",
         description: "Dismiss search",
+        group: ShortcutGroup::Search,
     },
     ActionMeta {
         name: "clear_scroll_history",
         factory: || Box::new(ClearScrollHistory),
         context: "Terminal",
         description: "Clear scroll history",
+        group: ShortcutGroup::Terminal,
     },
     ActionMeta {
         name: "reset_terminal",
         factory: || Box::new(ResetTerminal),
         context: "Terminal",
         description: "Reset terminal",
+        group: ShortcutGroup::Terminal,
     },
     // US-012: Quit menu action (bound to cmd-q on macOS via
     // MACOS_ONLY_DEFAULTS; also reachable from PaneFlow > Quit PaneFlow).
@@ -388,6 +490,7 @@ pub(super) const ACTIONS: &[ActionMeta] = &[
         factory: || Box::new(Quit),
         context: "",
         description: "Quit",
+        group: ShortcutGroup::Application,
     },
     // US-022: Markdown pane navigation. Scroll + copy bind on the root
     // `Markdown` context; find-overlay actions bind on `MarkdownSearch`
@@ -397,42 +500,49 @@ pub(super) const ACTIONS: &[ActionMeta] = &[
         factory: || Box::new(MarkdownScrollPageUp),
         context: "Markdown",
         description: "Markdown: scroll up one page",
+        group: ShortcutGroup::Markdown,
     },
     ActionMeta {
         name: "markdown_scroll_page_down",
         factory: || Box::new(MarkdownScrollPageDown),
         context: "Markdown",
         description: "Markdown: scroll down one page",
+        group: ShortcutGroup::Markdown,
     },
     ActionMeta {
         name: "markdown_find_open",
         factory: || Box::new(MarkdownFindOpen),
         context: "Markdown",
         description: "Markdown: open find bar",
+        group: ShortcutGroup::Markdown,
     },
     ActionMeta {
         name: "markdown_copy",
         factory: || Box::new(MarkdownCopy),
         context: "Markdown",
         description: "Markdown: copy selection / current match",
+        group: ShortcutGroup::Markdown,
     },
     ActionMeta {
         name: "markdown_find_next",
         factory: || Box::new(MarkdownFindNext),
         context: "MarkdownSearch",
         description: "Markdown: jump to next match",
+        group: ShortcutGroup::Markdown,
     },
     ActionMeta {
         name: "markdown_find_prev",
         factory: || Box::new(MarkdownFindPrev),
         context: "MarkdownSearch",
         description: "Markdown: jump to previous match",
+        group: ShortcutGroup::Markdown,
     },
     ActionMeta {
         name: "markdown_find_dismiss",
         factory: || Box::new(MarkdownFindDismiss),
         context: "MarkdownSearch",
         description: "Markdown: close find bar",
+        group: ShortcutGroup::Markdown,
     },
     // US-003 (prd-git-diff-mode-2026-Q3.md): toggle the dedicated Git
     // Diff mode (AppMode::Diff).
@@ -441,12 +551,14 @@ pub(super) const ACTIONS: &[ActionMeta] = &[
         factory: || Box::new(crate::OpenDiffView),
         context: "",
         description: "Toggle Git Diff view",
+        group: ShortcutGroup::Diff,
     },
     ActionMeta {
         name: "toggle_files_sidebar",
         factory: || Box::new(crate::ToggleFilesSidebar),
         context: "",
         description: "Toggle Files sidebar",
+        group: ShortcutGroup::Diff,
     },
     // US-003 (prd-ai-in-diff-2026-Q3.md): copy the hunk under the cursor as a
     // unified diff. Scoped to the DiffView context so Ctrl+Shift+C there never
@@ -456,6 +568,7 @@ pub(super) const ACTIONS: &[ActionMeta] = &[
         factory: || Box::new(crate::CopyDiffHunk),
         context: "DiffView",
         description: "Copy hunk as diff",
+        group: ShortcutGroup::Diff,
     },
     // EP-003 US-009 (review redesign): keyboard-first review loop.
     // Keep these off embedded terminals and text widgets inside DiffView.
@@ -464,24 +577,28 @@ pub(super) const ACTIONS: &[ActionMeta] = &[
         factory: || Box::new(crate::DiffNextHunk),
         context: "DiffView && !Terminal && !TextInput && !PaneflowTextArea",
         description: "Diff: next hunk",
+        group: ShortcutGroup::Diff,
     },
     ActionMeta {
         name: "diff_prev_hunk",
         factory: || Box::new(crate::DiffPrevHunk),
         context: "DiffView && !Terminal && !TextInput && !PaneflowTextArea",
         description: "Diff: previous hunk",
+        group: ShortcutGroup::Diff,
     },
     ActionMeta {
         name: "diff_toggle_view",
         factory: || Box::new(crate::DiffToggleView),
         context: "DiffView && !Terminal && !TextInput && !PaneflowTextArea",
         description: "Diff: toggle unified / split",
+        group: ShortcutGroup::Diff,
     },
     ActionMeta {
         name: "diff_toggle_sync",
         factory: || Box::new(crate::DiffToggleSync),
         context: "DiffView && !Terminal && !TextInput && !PaneflowTextArea",
         description: "Diff: toggle scroll sync",
+        group: ShortcutGroup::Diff,
     },
     // EP-005 US-018 (prd-file-editor-2026-Q3): the diff dock's new-tab chords.
     // Kept off terminals and text widgets - Ctrl+G is BEL and Ctrl+J is LF in a
@@ -493,18 +610,21 @@ pub(super) const ACTIONS: &[ActionMeta] = &[
         factory: || Box::new(crate::DiffNewFileTab),
         context: "!Terminal && !TextInput && !PaneflowTextArea && !CodeEditor",
         description: "Diff dock: open a file tab",
+        group: ShortcutGroup::Diff,
     },
     ActionMeta {
         name: "diff_new_terminal_tab",
         factory: || Box::new(crate::DiffNewTerminalTab),
         context: "!Terminal && !TextInput && !PaneflowTextArea && !CodeEditor",
         description: "Diff dock: open a terminal tab",
+        group: ShortcutGroup::Diff,
     },
     ActionMeta {
         name: "diff_dismiss",
         factory: || Box::new(crate::DiffDismiss),
         context: "DiffView && !Terminal && !TextInput && !PaneflowTextArea",
         description: "Diff: close popover / refocus body",
+        group: ShortcutGroup::Diff,
     },
     // EP-001 (CLI Cockpit): CLI cockpit steering.
     // Global context - the handlers gate on `AppMode::Cli` themselves.
@@ -513,18 +633,21 @@ pub(super) const ACTIONS: &[ActionMeta] = &[
         factory: || Box::new(crate::OpenComposer),
         context: "",
         description: "Open prompt composer",
+        group: ShortcutGroup::Agents,
     },
     ActionMeta {
         name: "toggle_broadcast_member",
         factory: || Box::new(crate::ToggleBroadcastMember),
         context: "",
         description: "Toggle pane in broadcast group",
+        group: ShortcutGroup::Agents,
     },
     ActionMeta {
         name: "open_broadcast_groups",
         factory: || Box::new(crate::OpenBroadcastGroups),
         context: "",
         description: "Broadcast groups",
+        group: ShortcutGroup::Agents,
     },
     // EP-002 (CLI Cockpit): triage & launch.
     ActionMeta {
@@ -532,12 +655,14 @@ pub(super) const ACTIONS: &[ActionMeta] = &[
         factory: || Box::new(crate::OpenAttentionQueue),
         context: "",
         description: "Attention queue",
+        group: ShortcutGroup::Agents,
     },
     ActionMeta {
         name: "open_launch_pad",
         factory: || Box::new(crate::OpenLaunchPad),
         context: "",
         description: "Launch Pad",
+        group: ShortcutGroup::Agents,
     },
 ];
 

--- a/src-app/src/main.rs
+++ b/src-app/src/main.rs
@@ -2416,6 +2416,15 @@ fn mount_paneflow_app(window: &mut Window, cx: &mut App) -> Entity<PaneFlowApp> 
             let Some(app) = weak.upgrade() else {
                 return;
             };
+            // This runs for every keystroke in the app, terminal typing
+            // included, so the common answer has to be cheap. `Entity::update`
+            // opens an update cycle and flushes the effect queue on exit;
+            // doing that mid-key-dispatch just to read one field would put a
+            // flush on the keystroke-to-pixel path AGENTS.md protects. Read
+            // the gate first and only take the update when the page is open.
+            if app.read(cx).settings_section != Some(SettingsSection::Shortcuts) {
+                return;
+            }
             let consumed = app.update(cx, |this, cx| {
                 this.intercept_shortcut_keystroke(&event.keystroke, window, cx)
             });

--- a/src-app/src/main.rs
+++ b/src-app/src/main.rs
@@ -1010,6 +1010,20 @@ struct PaneFlowApp {
     effective_shortcuts: Vec<keybindings::ShortcutEntry>,
     /// Index of the shortcut row currently being recorded (`None` = not recording).
     recording_shortcut_idx: Option<usize>,
+    /// Free-text filter for the Shortcuts page. Matches the action description
+    /// *and* the rendered keystroke, so "ctrl+shift" and "workspace" both work.
+    shortcut_search_input: gpui::Entity<crate::widgets::text_input::TextInput>,
+    /// Chord captured by the Shortcuts page's key-capture mode, already
+    /// formatted for display. `Some` only while a chord has been pressed; the
+    /// mode itself is [`Self::shortcut_capture_active`].
+    shortcut_captured_key: Option<String>,
+    /// Whether the Shortcuts page is in key-capture mode: the next chord filters
+    /// the list instead of typing into the search field. This answers "what
+    /// already owns this key?", which a text search cannot without knowing how
+    /// the chord is spelled.
+    shortcut_capture_active: bool,
+    /// Sections collapsed on the Shortcuts page. Empty = everything expanded.
+    collapsed_shortcut_groups: std::collections::HashSet<keybindings::ShortcutGroup>,
     /// Focus handle for the settings page (receives key events during recording/font search).
     settings_focus: FocusHandle,
     /// Cached list of monospace font family names from the system.

--- a/src-app/src/main.rs
+++ b/src-app/src/main.rs
@@ -1021,6 +1021,10 @@ struct PaneFlowApp {
     /// While this is set, [`Self::intercept_shortcut_keystroke`] swallows every
     /// chord before GPUI can dispatch its action.
     shortcut_capture_active: bool,
+    /// Whether "Reset to defaults" on the Shortcuts page is awaiting
+    /// confirmation. The reset rewrites every binding in `paneflow.json` with
+    /// no undo, so the button asks before it fires.
+    shortcut_reset_pending: bool,
     /// Sections collapsed on the Shortcuts page. Empty = everything expanded.
     collapsed_shortcut_groups: std::collections::HashSet<keybindings::ShortcutGroup>,
     /// Focus handle for the settings page (receives key events during recording/font search).

--- a/src-app/src/main.rs
+++ b/src-app/src/main.rs
@@ -1013,14 +1013,13 @@ struct PaneFlowApp {
     /// Free-text filter for the Shortcuts page. Matches the action description
     /// *and* the rendered keystroke, so "ctrl+shift" and "workspace" both work.
     shortcut_search_input: gpui::Entity<crate::widgets::text_input::TextInput>,
-    /// Chord captured by the Shortcuts page's key-capture mode, already
-    /// formatted for display. `Some` only while a chord has been pressed; the
-    /// mode itself is [`Self::shortcut_capture_active`].
-    shortcut_captured_key: Option<String>,
-    /// Whether the Shortcuts page is in key-capture mode: the next chord filters
-    /// the list instead of typing into the search field. This answers "what
-    /// already owns this key?", which a text search cannot without knowing how
-    /// the chord is spelled.
+    /// Whether the Shortcuts page is in key-capture mode: the pressed chord is
+    /// written into the search field instead of reaching the app, so the page
+    /// can answer "what already owns this key?" - which a text search cannot,
+    /// unless the user already knows how the chord is spelled.
+    ///
+    /// While this is set, [`Self::intercept_shortcut_keystroke`] swallows every
+    /// chord before GPUI can dispatch its action.
     shortcut_capture_active: bool,
     /// Sections collapsed on the Shortcuts page. Empty = everything expanded.
     collapsed_shortcut_groups: std::collections::HashSet<keybindings::ShortcutGroup>,
@@ -2403,6 +2402,24 @@ mod windows_startup_console_tests {
 fn mount_paneflow_app(window: &mut Window, cx: &mut App) -> Entity<PaneFlowApp> {
     let view = window.replace_root(cx, |_, cx| PaneFlowApp::new(cx));
     view.update(cx, |_, cx| {
+        // Shortcuts-page key capture and rebind recording have to see a chord
+        // *before* GPUI matches it against the keymap, or pressing Cmd+Q to
+        // find (or rebind) Quit simply quits. `intercept_keystrokes` is the
+        // only hook that runs that early; a key-down listener never fires at
+        // all once a binding has been dispatched and handled.
+        let weak = cx.weak_entity();
+        cx.intercept_keystrokes(move |event, window, cx| {
+            let Some(app) = weak.upgrade() else {
+                return;
+            };
+            let consumed = app.update(cx, |this, cx| {
+                this.intercept_shortcut_keystroke(&event.keystroke, window, cx)
+            });
+            if consumed {
+                cx.stop_propagation();
+            }
+        })
+        .detach();
         let subscription = cx.observe_window_bounds(window, |this, window, cx| {
             crate::window_state::record_windowed_size(window);
             #[cfg(target_os = "linux")]

--- a/src-app/src/settings/chrome.rs
+++ b/src-app/src/settings/chrome.rs
@@ -534,6 +534,13 @@ impl PaneFlowApp {
             let config = paneflow_config::loader::load_config();
             crate::keybindings::apply_keybindings(cx, &config.shortcuts);
         }
+        // Shortcuts-page ephemeral state. The armed "Reset" confirmation is the
+        // one that matters: left standing across a nav round-trip, it turns a
+        // stray click into "every binding erased, no undo". The capture mode
+        // and the filter are cleared for the same reason - a page that comes
+        // back silently swallowing keystrokes reads as broken.
+        self.shortcut_reset_pending = false;
+        self.clear_shortcut_filters(cx);
         if section == SettingsSection::McpServers {
             self.refresh_mcp_status(cx);
         }

--- a/src-app/src/settings/components.rs
+++ b/src-app/src/settings/components.rs
@@ -273,6 +273,14 @@ pub fn secondary_button(
     .on_click(on_click)
 }
 
+/// The one destructive red in the app: Apple's systemRed. Hardcoded rather
+/// than themed because `accent` and `text` are independent per theme and their
+/// pairing is not guaranteed legible, while red-on-white reads the same
+/// everywhere and carries the warning by itself.
+pub fn destructive_color() -> Hsla {
+    Hsla::from(gpui::rgb(0xff453a))
+}
+
 /// A [`secondary_button`] in destructive red, for an action that cannot be
 /// undone. Red fill with a white label rather than theme tokens: `accent` and
 /// `text` are independent per theme and their pairing is not guaranteed to be
@@ -281,12 +289,8 @@ pub fn secondary_button(
 ///
 /// Returns the element unclicked so the caller attaches its own listener; a
 /// destructive action is never generic enough to bake in here.
-pub fn destructive_button(
-    id: &'static str,
-    label: &'static str,
-    _ui: crate::theme::UiColors,
-) -> gpui::Stateful<gpui::Div> {
-    let resting = Hsla::from(gpui::rgb(0xff453a));
+pub fn destructive_button(id: &'static str, label: &'static str) -> gpui::Stateful<gpui::Div> {
+    let resting = destructive_color();
     let hovered = Hsla {
         l: (resting.l - 0.05).max(0.0),
         ..resting

--- a/src-app/src/settings/components.rs
+++ b/src-app/src/settings/components.rs
@@ -273,6 +273,42 @@ pub fn secondary_button(
     .on_click(on_click)
 }
 
+/// A [`secondary_button`] in destructive red, for an action that cannot be
+/// undone. Red fill with a white label rather than theme tokens: `accent` and
+/// `text` are independent per theme and their pairing is not guaranteed to be
+/// legible, while red-on-white reads the same everywhere and carries the
+/// warning by itself.
+///
+/// Returns the element unclicked so the caller attaches its own listener; a
+/// destructive action is never generic enough to bake in here.
+pub fn destructive_button(
+    id: &'static str,
+    label: &'static str,
+    _ui: crate::theme::UiColors,
+) -> gpui::Stateful<gpui::Div> {
+    let resting = Hsla::from(gpui::rgb(0xff453a));
+    let hovered = Hsla {
+        l: (resting.l - 0.05).max(0.0),
+        ..resting
+    };
+
+    squircle_skin(
+        div()
+            .id(id)
+            .px(px(10.))
+            .py(px(4.))
+            .cursor(CursorStyle::PointingHand)
+            .text_size(px(12.))
+            .font_weight(gpui::FontWeight::MEDIUM)
+            .text_color(gpui::white()),
+        format!("{id}-squircle"),
+        ROW_RADIUS,
+        Some(resting),
+        Some(hovered),
+    )
+    .child(label)
+}
+
 // ── Codex-style select / dropdown primitives ─────────────────────────────
 //
 // Shared by the General, Themes (font picker) and Terminal settings pages so

--- a/src-app/src/settings/tabs/shortcuts.rs
+++ b/src-app/src/settings/tabs/shortcuts.rs
@@ -26,12 +26,15 @@ use gpui::{
     prelude::*, px, svg,
 };
 
+use std::collections::HashMap;
+
 use crate::keybindings::ShortcutGroup;
 use crate::settings::components::{
-    SETTINGS_CONTROL_CORNER_RADIUS, destructive_button, hairline, secondary_button, setting_card,
+    SETTINGS_CONTROL_CORNER_RADIUS, destructive_button, hairline, secondary_button,
+    section_header_with_action, setting_card,
 };
 use crate::terminal::element::{MIN_APCA_CONTRAST, ensure_minimum_contrast};
-use crate::ui_primitives::{LABEL_SM, ROW_RADIUS, squircle_skin};
+use crate::ui_primitives::{ROW_RADIUS, squircle_skin};
 use crate::{PaneFlowApp, config_writer, keybindings};
 
 /// A row that survived the filter, paired with its index into the unfiltered
@@ -63,6 +66,12 @@ impl PaneFlowApp {
             if query.is_empty() {
                 return true;
             }
+            // A captured chord asks "what owns exactly this?". macOS glyphs
+            // concatenate with no separator, so a substring test would answer
+            // ⌘⇧D with every row that merely contains it, ⌃⌘⇧D included.
+            if self.shortcut_capture_active {
+                return entry.key.to_lowercase() == query;
+            }
             entry.description.to_lowercase().contains(&query)
                 || entry.key.to_lowercase().contains(&query)
                 // `key` renders Apple glyphs on macOS, so the ASCII spellings
@@ -70,18 +79,21 @@ impl PaneFlowApp {
                 || entry.search_key.contains(&query)
         };
 
+        // One pass over the entries rather than one per section: this runs on
+        // the render thread for every keystroke typed into the filter.
+        let mut by_group: HashMap<ShortcutGroup, Vec<VisibleRow<'_>>> = HashMap::new();
+        for (idx, entry) in self.effective_shortcuts.iter().enumerate() {
+            if matches(entry) {
+                by_group
+                    .entry(entry.group)
+                    .or_default()
+                    .push(VisibleRow { idx, entry });
+            }
+        }
+
         ShortcutGroup::ALL
             .iter()
-            .filter_map(|group| {
-                let rows: Vec<VisibleRow<'_>> = self
-                    .effective_shortcuts
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, entry)| entry.group == *group && matches(entry))
-                    .map(|(idx, entry)| VisibleRow { idx, entry })
-                    .collect();
-                (!rows.is_empty()).then_some((*group, rows))
-            })
+            .filter_map(|group| by_group.remove(group).map(|rows| (*group, rows)))
             .collect()
     }
 
@@ -103,7 +115,7 @@ impl PaneFlowApp {
             .flex_col()
             .gap(px(16.))
             .child(toolbar)
-            .child(self.render_shortcut_group_controls(ui, &groups, cx));
+            .child(self.render_shortcut_group_controls(ui, &groups, filtering, cx));
 
         if groups.is_empty() {
             column = column.child(
@@ -250,7 +262,7 @@ impl PaneFlowApp {
                         }),
                     ))
                     .child(
-                        destructive_button("reset-shortcuts-confirm", "Reset", ui).on_click(
+                        destructive_button("reset-shortcuts-confirm", "Reset").on_click(
                             cx.listener(|this, _: &ClickEvent, _w, cx| {
                                 config_writer::reset_shortcuts();
                                 let config = paneflow_config::loader::load_config();
@@ -279,13 +291,23 @@ impl PaneFlowApp {
         row.into_any_element()
     }
 
-    /// The "Expand all / Collapse all" control above the sections.
+    /// The "Bindings" eyebrow, with an "Expand all" / "Collapse all" action.
+    ///
+    /// The action is dropped while a filter is active: `render_shortcut_section`
+    /// forces every matching section open for the duration of a query, so the
+    /// button could only ever be a no-op there - it would set the fold state
+    /// and change nothing on screen.
     fn render_shortcut_group_controls(
         &self,
         ui: crate::theme::UiColors,
         groups: &[(ShortcutGroup, Vec<VisibleRow<'_>>)],
+        filtering: bool,
         cx: &mut Context<Self>,
     ) -> AnyElement {
+        if filtering {
+            return section_header_with_action(ui, "Bindings", div()).into_any_element();
+        }
+
         // Offer whichever action actually changes something: if every visible
         // section is already folded, the only useful verb is "expand".
         let all_collapsed = !groups.is_empty()
@@ -298,19 +320,10 @@ impl PaneFlowApp {
             ("Collapse all", true)
         };
 
-        div()
-            .flex()
-            .flex_row()
-            .items_center()
-            .justify_between()
-            .gap(px(12.))
-            .child(
-                div()
-                    .text_size(LABEL_SM)
-                    .text_color(ui.muted)
-                    .child("Bindings"),
-            )
-            .child(secondary_button(
+        section_header_with_action(
+            ui,
+            "Bindings",
+            secondary_button(
                 "shortcut-toggle-all",
                 label,
                 ui,
@@ -322,8 +335,9 @@ impl PaneFlowApp {
                     }
                     cx.notify();
                 }),
-            ))
-            .into_any_element()
+            ),
+        )
+        .into_any_element()
     }
 
     /// One collapsible section: a clickable header, then its rows.
@@ -423,7 +437,14 @@ impl PaneFlowApp {
                 .bg(ui.accent)
                 .text_size(px(11.))
                 .font_weight(gpui::FontWeight::SEMIBOLD)
-                .text_color(ui.text)
+                // Same APCA lift as the capture toggle: on themes where accent
+                // and text nearly coincide, a plain `text` label would leave
+                // the armed row looking like an empty pill.
+                .text_color(ensure_minimum_contrast(
+                    ui.text,
+                    ui.accent,
+                    MIN_APCA_CONTRAST,
+                ))
                 .child("Press a key…")
         } else {
             div()

--- a/src-app/src/settings/tabs/shortcuts.rs
+++ b/src-app/src/settings/tabs/shortcuts.rs
@@ -1,29 +1,252 @@
-//! "Shortcuts" settings tab - agents-styled list of every rebindable
+//! "Shortcuts" settings tab - grouped, searchable list of every rebindable
 //! action with click-to-record key capture.
 //!
-//! Layout: a "Bindings" eyebrow with an inline "Reset to defaults" button on
-//! the right, then a single `setting_card` containing one row per shortcut,
-//! separated by 1px hairlines. The card carries 4px of padding so a hovered row
-//! reads as its own squircle inside it, the way a menu row does on the rail -
-//! a full-bleed hover fill would square the card's own corners instead. Click capture is driven by
-//! `PaneFlowApp::handle_shortcut_recording` (in `app::settings`).
+//! The page used to be one flat card of ~80 rows in registry order, which made
+//! finding a binding a scrolling exercise and answering "what already owns this
+//! chord?" impossible. Three things fix that:
+//!
+//! - **Sections.** Rows are filed under [`ShortcutGroup`], declared on the
+//!   action in `keybindings::registry` rather than implied by table order.
+//!   Each section collapses, and a header control folds or unfolds all of them.
+//! - **Text filter.** One field matching the action description *and* the
+//!   rendered keystroke, so "workspace" and "ctrl+shift" both narrow the list.
+//! - **Key capture.** A toggle that turns the next pressed chord into the
+//!   filter (the VS Code / KDE recipe). Text search cannot answer "who owns
+//!   this key?" unless you already know how the chord is spelled; capture can.
+//!
+//! Filtering auto-expands: a collapsed section that contains a match opens for
+//! the duration of the query, so a hit is never hidden behind a closed header.
+//! Rebind capture itself is still driven by
+//! `PaneFlowApp::handle_shortcut_recording` (in `app::settings`), and every row
+//! carries its index into the *unfiltered* `effective_shortcuts`, because that
+//! is what the rebind keys off.
 
 use gpui::{
-    ClickEvent, Context, InteractiveElement, IntoElement, ParentElement, Styled, div, prelude::*,
-    px,
+    AnyElement, ClickEvent, Context, InteractiveElement, IntoElement, ParentElement, Styled, div,
+    prelude::*, px, svg,
 };
 
+use crate::keybindings::ShortcutGroup;
 use crate::settings::components::{
-    SETTINGS_CONTROL_CORNER_RADIUS, hairline, secondary_button, section_header_with_action,
-    setting_card,
+    SETTINGS_CONTROL_CORNER_RADIUS, hairline, secondary_button, setting_card,
 };
-use crate::ui_primitives::{ROW_RADIUS, squircle_skin};
+use crate::ui_primitives::{LABEL_SM, ROW_RADIUS, squircle_skin};
 use crate::{PaneFlowApp, config_writer, keybindings};
 
+/// A row that survived the filter, paired with its index into the unfiltered
+/// `effective_shortcuts` - the index the rebind must use.
+struct VisibleRow<'a> {
+    idx: usize,
+    entry: &'a keybindings::ShortcutEntry,
+}
+
 impl PaneFlowApp {
+    /// Rows matching the active filter, bucketed by section in display order.
+    ///
+    /// Matching is case-insensitive and substring-based over both the action
+    /// description and the displayed keystroke. A captured chord is compared
+    /// against the whole keystroke instead, since a chord is an exact thing:
+    /// substring-matching "Ctrl+C" would also drag in "Ctrl+Shift+C".
+    fn filtered_shortcut_groups(
+        &self,
+        cx: &Context<Self>,
+    ) -> Vec<(ShortcutGroup, Vec<VisibleRow<'_>>)> {
+        let captured = self.shortcut_captured_key.as_deref();
+        let query = if captured.is_some() {
+            String::new()
+        } else {
+            self.shortcut_search_input
+                .read(cx)
+                .value()
+                .trim()
+                .to_lowercase()
+        };
+
+        let matches = |entry: &keybindings::ShortcutEntry| -> bool {
+            if let Some(chord) = captured {
+                return entry.key.eq_ignore_ascii_case(chord);
+            }
+            if query.is_empty() {
+                return true;
+            }
+            entry.description.to_lowercase().contains(&query)
+                || entry.key.to_lowercase().contains(&query)
+                // `key` renders Apple glyphs on macOS, so the ASCII spellings
+                // are what makes "cmd+shift" / "ctrl+shift" find anything there.
+                || entry.search_key.contains(&query)
+        };
+
+        ShortcutGroup::ALL
+            .iter()
+            .filter_map(|group| {
+                let rows: Vec<VisibleRow<'_>> = self
+                    .effective_shortcuts
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, entry)| entry.group == *group && matches(entry))
+                    .map(|(idx, entry)| VisibleRow { idx, entry })
+                    .collect();
+                (!rows.is_empty()).then_some((*group, rows))
+            })
+            .collect()
+    }
+
     pub(crate) fn render_shortcuts_content(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let ui = crate::theme::ui_colors();
-        let recording_idx = self.recording_shortcut_idx;
+        let filtering = self.shortcut_captured_key.is_some()
+            || !self
+                .shortcut_search_input
+                .read(cx)
+                .value()
+                .trim()
+                .is_empty();
+
+        let groups = self.filtered_shortcut_groups(cx);
+        let total_visible: usize = groups.iter().map(|(_, rows)| rows.len()).sum();
+
+        let toolbar = self.render_shortcut_toolbar(ui, filtering, cx);
+
+        let mut column = div()
+            .flex()
+            .flex_col()
+            .gap(px(16.))
+            .child(toolbar)
+            .child(self.render_shortcut_group_controls(ui, &groups, cx));
+
+        if groups.is_empty() {
+            column = column.child(
+                setting_card(ui).p(px(4.)).child(
+                    div()
+                        .px(px(8.))
+                        .py(px(14.))
+                        .text_size(px(12.))
+                        .text_color(ui.muted)
+                        .child("No shortcut matches this filter"),
+                ),
+            );
+        } else {
+            for (group, rows) in &groups {
+                column =
+                    column.child(self.render_shortcut_section(ui, *group, rows, filtering, cx));
+            }
+        }
+
+        let hint = if self.shortcut_capture_active {
+            "Press a chord to find what owns it. Escape to leave capture mode."
+        } else {
+            "Click a row to record a new shortcut. Escape to cancel."
+        };
+
+        column.child(
+            div()
+                .flex()
+                .flex_row()
+                .items_center()
+                .justify_between()
+                .gap(px(12.))
+                .pt(px(2.))
+                .child(
+                    div()
+                        .text_size(px(11.))
+                        .text_color(ui.muted)
+                        .child(hint.to_string()),
+                )
+                .child(div().text_size(px(11.)).text_color(ui.muted).child(format!(
+                    "{total_visible} of {}",
+                    self.effective_shortcuts.len()
+                ))),
+        )
+    }
+
+    /// Search field + key-capture toggle + "Reset to defaults".
+    fn render_shortcut_toolbar(
+        &self,
+        ui: crate::theme::UiColors,
+        filtering: bool,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let capture_active = self.shortcut_capture_active;
+
+        // While capture is armed the field stops being a text box and becomes a
+        // readout of the pressed chord: typing is routed to the capture handler,
+        // so a live text cursor there would be a lie.
+        let field: AnyElement = if capture_active {
+            let label = self
+                .shortcut_captured_key
+                .clone()
+                .unwrap_or_else(|| "Press a chord…".to_string());
+            div()
+                .flex_1()
+                .min_w_0()
+                .text_size(px(12.))
+                .text_color(if self.shortcut_captured_key.is_some() {
+                    ui.text
+                } else {
+                    ui.muted
+                })
+                .truncate()
+                .child(label)
+                .into_any_element()
+        } else {
+            crate::ui_primitives::filter_pill(
+                "shortcut-search",
+                "shortcut-search-clear",
+                ui,
+                self.shortcut_search_input.clone(),
+                filtering,
+                cx.listener(|this, _: &ClickEvent, _window, cx| {
+                    this.clear_shortcut_filters(cx);
+                    cx.notify();
+                }),
+            )
+            .flex_1()
+            .min_w_0()
+            .into_any_element()
+        };
+
+        let capture_toggle = squircle_skin(
+            div()
+                .id("shortcut-capture-toggle")
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap(px(6.))
+                .px(px(10.))
+                .py(px(5.)),
+            "shortcut-capture-skin",
+            ROW_RADIUS,
+            // Armed state is a resting fill, not just a hover: the mode
+            // swallows keystrokes, so it must be visible without pointing at it.
+            capture_active.then_some(ui.accent),
+            Some(ui.subtle),
+        )
+        .on_click(cx.listener(move |this, _: &ClickEvent, window, cx| {
+            let next = !this.shortcut_capture_active;
+            this.set_shortcut_capture(next, cx);
+            if next {
+                // The chord has to land on the settings surface, not on
+                // whatever held focus before.
+                this.settings_focus.focus(window, cx);
+            }
+            cx.notify();
+        }))
+        .child(
+            svg()
+                .size(px(13.))
+                .flex_none()
+                .path("icons/keyboard.svg")
+                .text_color(if capture_active { ui.text } else { ui.muted }),
+        )
+        .child(
+            div()
+                .text_size(px(11.))
+                .text_color(if capture_active { ui.text } else { ui.muted })
+                .child(if capture_active {
+                    "Capturing"
+                } else {
+                    "Find by key"
+                }),
+        );
 
         let reset_btn = secondary_button(
             "reset-shortcuts",
@@ -39,85 +262,210 @@ impl PaneFlowApp {
             }),
         );
 
-        let header = section_header_with_action(ui, "Bindings", reset_btn);
+        div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(8.))
+            .child(field)
+            .child(capture_toggle)
+            .child(reset_btn)
+            .into_any_element()
+    }
 
-        let mut list = setting_card(ui).p(px(4.));
-
-        let total = self.effective_shortcuts.len();
-        for (i, entry) in self.effective_shortcuts.iter().enumerate() {
-            let is_recording = recording_idx == Some(i);
-            let is_last = i + 1 == total;
-
-            let key_badge = if is_recording {
-                div()
-                    .px(px(10.))
-                    .py(px(3.))
-                    .rounded(SETTINGS_CONTROL_CORNER_RADIUS)
-                    .bg(ui.accent)
-                    .text_size(px(11.))
-                    .font_weight(gpui::FontWeight::SEMIBOLD)
-                    .text_color(ui.text)
-                    .child("Press a key…")
-            } else {
-                div()
-                    .px(px(10.))
-                    .py(px(3.))
-                    .rounded(SETTINGS_CONTROL_CORNER_RADIUS)
-                    .bg(ui.subtle)
-                    .text_size(px(11.))
-                    .font_weight(gpui::FontWeight::MEDIUM)
-                    .text_color(ui.text)
-                    .child(entry.key.clone())
-            };
-
-            let row = squircle_skin(
-                div()
-                    .id(("shortcut", i))
-                    .flex()
-                    .flex_row()
-                    .items_center()
-                    .justify_between()
-                    .gap(px(12.))
-                    .px(px(8.))
-                    .py(px(10.)),
-                format!("shortcut-squircle-{i}"),
-                ROW_RADIUS,
-                None,
-                Some(ui.subtle),
-            )
-            .on_click(cx.listener(move |this, _: &ClickEvent, window, cx| {
-                this.recording_shortcut_idx = Some(i);
-                this.settings_focus.focus(window, cx);
-                cx.notify();
-            }))
-            .child(
-                div()
-                    .flex_1()
-                    .min_w_0()
-                    .text_size(px(13.))
-                    .text_color(ui.text)
-                    .truncate()
-                    .child(entry.description.clone()),
-            )
-            .child(key_badge);
-
-            list = list.child(row);
-            if !is_last {
-                list = list.child(hairline(ui));
-            }
-        }
-
-        let hint = div()
-            .pt(px(10.))
-            .text_size(px(11.))
-            .text_color(ui.muted)
-            .child("Click a row to record a new shortcut. Escape to cancel.");
+    /// The "Expand all / Collapse all" control above the sections.
+    fn render_shortcut_group_controls(
+        &self,
+        ui: crate::theme::UiColors,
+        groups: &[(ShortcutGroup, Vec<VisibleRow<'_>>)],
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        // Offer whichever action actually changes something: if every visible
+        // section is already folded, the only useful verb is "expand".
+        let all_collapsed = !groups.is_empty()
+            && groups
+                .iter()
+                .all(|(group, _)| self.collapsed_shortcut_groups.contains(group));
+        let (label, collapse) = if all_collapsed {
+            ("Expand all", false)
+        } else {
+            ("Collapse all", true)
+        };
 
         div()
             .flex()
-            .flex_col()
-            .child(header)
-            .child(list)
-            .child(hint)
+            .flex_row()
+            .items_center()
+            .justify_between()
+            .gap(px(12.))
+            .child(
+                div()
+                    .text_size(LABEL_SM)
+                    .text_color(ui.muted)
+                    .child("Bindings"),
+            )
+            .child(secondary_button(
+                "shortcut-toggle-all",
+                label,
+                ui,
+                cx.listener(move |this, _: &ClickEvent, _w, cx| {
+                    this.collapsed_shortcut_groups.clear();
+                    if collapse {
+                        this.collapsed_shortcut_groups
+                            .extend(ShortcutGroup::ALL.iter().copied());
+                    }
+                    cx.notify();
+                }),
+            ))
+            .into_any_element()
+    }
+
+    /// One collapsible section: a clickable header, then its rows.
+    fn render_shortcut_section(
+        &self,
+        ui: crate::theme::UiColors,
+        group: ShortcutGroup,
+        rows: &[VisibleRow<'_>],
+        filtering: bool,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        // A filter overrides the fold: hiding a match behind a closed header
+        // would make the search look broken. The user's fold state is kept, not
+        // cleared, so it comes back when the query does.
+        let collapsed = !filtering && self.collapsed_shortcut_groups.contains(&group);
+        let count = rows.len();
+
+        let header = squircle_skin(
+            div()
+                .id(("shortcut-group", group as usize))
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap(px(8.))
+                .px(px(8.))
+                .py(px(6.)),
+            format!("shortcut-group-skin-{}", group as usize),
+            ROW_RADIUS,
+            None,
+            Some(ui.subtle),
+        )
+        .on_click(cx.listener(move |this, _: &ClickEvent, _w, cx| {
+            if !this.collapsed_shortcut_groups.remove(&group) {
+                this.collapsed_shortcut_groups.insert(group);
+            }
+            cx.notify();
+        }))
+        .child(
+            svg()
+                .size(px(11.))
+                .flex_none()
+                .path(if collapsed {
+                    "icons/chevron-right.svg"
+                } else {
+                    "icons/chevron-down.svg"
+                })
+                .text_color(ui.muted),
+        )
+        .child(
+            div()
+                .flex_1()
+                .min_w_0()
+                .text_size(px(12.))
+                .font_weight(gpui::FontWeight::MEDIUM)
+                .text_color(ui.text)
+                .truncate()
+                .child(group.label()),
+        )
+        .child(
+            div()
+                .text_size(px(11.))
+                .text_color(ui.muted)
+                .child(count.to_string()),
+        );
+
+        let mut section = div().flex().flex_col().gap(px(6.)).child(header);
+
+        if !collapsed {
+            let mut card = setting_card(ui).p(px(4.));
+            for (position, row) in rows.iter().enumerate() {
+                card = card.child(self.render_shortcut_row(ui, row, cx));
+                if position + 1 != count {
+                    card = card.child(hairline(ui));
+                }
+            }
+            section = section.child(card);
+        }
+
+        section.into_any_element()
+    }
+
+    fn render_shortcut_row(
+        &self,
+        ui: crate::theme::UiColors,
+        row: &VisibleRow<'_>,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let idx = row.idx;
+        let is_recording = self.recording_shortcut_idx == Some(idx);
+        let unassigned = row.entry.key == "Unassigned";
+
+        let key_badge = if is_recording {
+            div()
+                .px(px(10.))
+                .py(px(3.))
+                .rounded(SETTINGS_CONTROL_CORNER_RADIUS)
+                .bg(ui.accent)
+                .text_size(px(11.))
+                .font_weight(gpui::FontWeight::SEMIBOLD)
+                .text_color(ui.text)
+                .child("Press a key…")
+        } else {
+            div()
+                .px(px(10.))
+                .py(px(3.))
+                .rounded(SETTINGS_CONTROL_CORNER_RADIUS)
+                .bg(ui.subtle)
+                .text_size(px(11.))
+                .font_weight(gpui::FontWeight::MEDIUM)
+                // An unassigned row is an absence, not a binding, so it reads
+                // muted instead of sitting at the same weight as a real chord.
+                .text_color(if unassigned { ui.muted } else { ui.text })
+                .child(row.entry.key.clone())
+        };
+
+        squircle_skin(
+            div()
+                .id(("shortcut", idx))
+                .flex()
+                .flex_row()
+                .items_center()
+                .justify_between()
+                .gap(px(12.))
+                .px(px(8.))
+                .py(px(10.)),
+            format!("shortcut-squircle-{idx}"),
+            ROW_RADIUS,
+            None,
+            Some(ui.subtle),
+        )
+        .on_click(cx.listener(move |this, _: &ClickEvent, window, cx| {
+            // Recording a rebind and capturing a search chord both want the
+            // keyboard; arming one disarms the other.
+            this.set_shortcut_capture(false, cx);
+            this.recording_shortcut_idx = Some(idx);
+            this.settings_focus.focus(window, cx);
+            cx.notify();
+        }))
+        .child(
+            div()
+                .flex_1()
+                .min_w_0()
+                .text_size(px(13.))
+                .text_color(ui.text)
+                .truncate()
+                .child(row.entry.description.clone()),
+        )
+        .child(key_badge)
+        .into_any_element()
     }
 }

--- a/src-app/src/settings/tabs/shortcuts.rs
+++ b/src-app/src/settings/tabs/shortcuts.rs
@@ -28,8 +28,9 @@ use gpui::{
 
 use crate::keybindings::ShortcutGroup;
 use crate::settings::components::{
-    SETTINGS_CONTROL_CORNER_RADIUS, hairline, secondary_button, setting_card,
+    SETTINGS_CONTROL_CORNER_RADIUS, destructive_button, hairline, secondary_button, setting_card,
 };
+use crate::terminal::element::{MIN_APCA_CONTRAST, ensure_minimum_contrast};
 use crate::ui_primitives::{LABEL_SM, ROW_RADIUS, squircle_skin};
 use crate::{PaneFlowApp, config_writer, keybindings};
 
@@ -158,6 +159,11 @@ impl PaneFlowApp {
         cx: &mut Context<Self>,
     ) -> AnyElement {
         let capture_active = self.shortcut_capture_active;
+        // `accent` and `text` are independent theme tokens: on vercel_dark they
+        // are #ffffff and #ededed, so a plain `text` label on an `accent` fill
+        // is invisible. Lift the label off the fill with the same APCA pass the
+        // terminal uses for selected text.
+        let on_accent = ensure_minimum_contrast(ui.text, ui.accent, MIN_APCA_CONTRAST);
 
         // One field in both modes. In capture mode the interceptor writes the
         // pressed chord straight into it, so the user always reads back exactly
@@ -207,12 +213,12 @@ impl PaneFlowApp {
                 .size(px(13.))
                 .flex_none()
                 .path("icons/keyboard.svg")
-                .text_color(if capture_active { ui.text } else { ui.muted }),
+                .text_color(if capture_active { on_accent } else { ui.muted }),
         )
         .child(
             div()
                 .text_size(px(11.))
-                .text_color(if capture_active { ui.text } else { ui.muted })
+                .text_color(if capture_active { on_accent } else { ui.muted })
                 .child(if capture_active {
                     "Capturing"
                 } else {
@@ -220,29 +226,68 @@ impl PaneFlowApp {
                 }),
         );
 
-        let reset_btn = secondary_button(
-            "reset-shortcuts",
-            "Reset to defaults",
-            ui,
-            cx.listener(|this, _: &ClickEvent, _w, cx| {
-                config_writer::reset_shortcuts();
-                let config = paneflow_config::loader::load_config();
-                keybindings::apply_keybindings(cx, &config.shortcuts);
-                this.effective_shortcuts = keybindings::effective_shortcuts(&config.shortcuts);
-                this.recording_shortcut_idx = None;
-                cx.notify();
-            }),
-        );
-
-        div()
+        // Resetting rewrites every binding in paneflow.json with no undo, so it
+        // asks first. A two-step inline confirm rather than a dialog: settings
+        // already live in a modal, and stacking a second one over it to ask a
+        // one-line question reads as heavier than the action deserves.
+        let mut row = div()
             .flex()
             .flex_row()
             .items_center()
             .gap(px(8.))
             .child(field)
-            .child(capture_toggle)
-            .child(reset_btn)
-            .into_any_element()
+            .child(capture_toggle);
+
+        row = if self.shortcut_reset_pending {
+            row.child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .gap(px(6.))
+                    .child(
+                        div()
+                            .text_size(px(11.))
+                            .text_color(ui.muted)
+                            .child("Reset all?"),
+                    )
+                    .child(secondary_button(
+                        "reset-shortcuts-cancel",
+                        "Cancel",
+                        ui,
+                        cx.listener(|this, _: &ClickEvent, _w, cx| {
+                            this.shortcut_reset_pending = false;
+                            cx.notify();
+                        }),
+                    ))
+                    .child(
+                        destructive_button("reset-shortcuts-confirm", "Reset", ui).on_click(
+                            cx.listener(|this, _: &ClickEvent, _w, cx| {
+                                config_writer::reset_shortcuts();
+                                let config = paneflow_config::loader::load_config();
+                                keybindings::apply_keybindings(cx, &config.shortcuts);
+                                this.effective_shortcuts =
+                                    keybindings::effective_shortcuts(&config.shortcuts);
+                                this.recording_shortcut_idx = None;
+                                this.shortcut_reset_pending = false;
+                                cx.notify();
+                            }),
+                        ),
+                    ),
+            )
+        } else {
+            row.child(secondary_button(
+                "reset-shortcuts",
+                "Reset to defaults",
+                ui,
+                cx.listener(|this, _: &ClickEvent, _w, cx| {
+                    this.shortcut_reset_pending = true;
+                    cx.notify();
+                }),
+            ))
+        };
+
+        row.into_any_element()
     }
 
     /// The "Expand all / Collapse all" control above the sections.

--- a/src-app/src/settings/tabs/shortcuts.rs
+++ b/src-app/src/settings/tabs/shortcuts.rs
@@ -95,7 +95,6 @@ impl PaneFlowApp {
             .is_empty();
 
         let groups = self.filtered_shortcut_groups(cx);
-        let total_visible: usize = groups.iter().map(|(_, rows)| rows.len()).sum();
 
         let toolbar = self.render_shortcut_toolbar(ui, filtering, cx);
 
@@ -130,24 +129,14 @@ impl PaneFlowApp {
             "Click a row to record a new shortcut. Escape to cancel."
         };
 
+        // No result count: the matching rows are on screen, and counting what
+        // the user can already see answers no question they have.
         column.child(
             div()
-                .flex()
-                .flex_row()
-                .items_center()
-                .justify_between()
-                .gap(px(12.))
                 .pt(px(2.))
-                .child(
-                    div()
-                        .text_size(px(11.))
-                        .text_color(ui.muted)
-                        .child(hint.to_string()),
-                )
-                .child(div().text_size(px(11.)).text_color(ui.muted).child(format!(
-                    "{total_visible} of {}",
-                    self.effective_shortcuts.len()
-                ))),
+                .text_size(px(11.))
+                .text_color(ui.muted)
+                .child(hint.to_string()),
         )
     }
 

--- a/src-app/src/settings/tabs/shortcuts.rs
+++ b/src-app/src/settings/tabs/shortcuts.rs
@@ -51,21 +51,14 @@ impl PaneFlowApp {
         &self,
         cx: &Context<Self>,
     ) -> Vec<(ShortcutGroup, Vec<VisibleRow<'_>>)> {
-        let captured = self.shortcut_captured_key.as_deref();
-        let query = if captured.is_some() {
-            String::new()
-        } else {
-            self.shortcut_search_input
-                .read(cx)
-                .value()
-                .trim()
-                .to_lowercase()
-        };
+        let query = self
+            .shortcut_search_input
+            .read(cx)
+            .value()
+            .trim()
+            .to_lowercase();
 
         let matches = |entry: &keybindings::ShortcutEntry| -> bool {
-            if let Some(chord) = captured {
-                return entry.key.eq_ignore_ascii_case(chord);
-            }
             if query.is_empty() {
                 return true;
             }
@@ -93,13 +86,12 @@ impl PaneFlowApp {
 
     pub(crate) fn render_shortcuts_content(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let ui = crate::theme::ui_colors();
-        let filtering = self.shortcut_captured_key.is_some()
-            || !self
-                .shortcut_search_input
-                .read(cx)
-                .value()
-                .trim()
-                .is_empty();
+        let filtering = !self
+            .shortcut_search_input
+            .read(cx)
+            .value()
+            .trim()
+            .is_empty();
 
         let groups = self.filtered_shortcut_groups(cx);
         let total_visible: usize = groups.iter().map(|(_, rows)| rows.len()).sum();
@@ -167,42 +159,22 @@ impl PaneFlowApp {
     ) -> AnyElement {
         let capture_active = self.shortcut_capture_active;
 
-        // While capture is armed the field stops being a text box and becomes a
-        // readout of the pressed chord: typing is routed to the capture handler,
-        // so a live text cursor there would be a lie.
-        let field: AnyElement = if capture_active {
-            let label = self
-                .shortcut_captured_key
-                .clone()
-                .unwrap_or_else(|| "Press a chord…".to_string());
-            div()
-                .flex_1()
-                .min_w_0()
-                .text_size(px(12.))
-                .text_color(if self.shortcut_captured_key.is_some() {
-                    ui.text
-                } else {
-                    ui.muted
-                })
-                .truncate()
-                .child(label)
-                .into_any_element()
-        } else {
-            crate::ui_primitives::filter_pill(
-                "shortcut-search",
-                "shortcut-search-clear",
-                ui,
-                self.shortcut_search_input.clone(),
-                filtering,
-                cx.listener(|this, _: &ClickEvent, _window, cx| {
-                    this.clear_shortcut_filters(cx);
-                    cx.notify();
-                }),
-            )
-            .flex_1()
-            .min_w_0()
-            .into_any_element()
-        };
+        // One field in both modes. In capture mode the interceptor writes the
+        // pressed chord straight into it, so the user always reads back exactly
+        // what was captured instead of trusting an invisible filter.
+        let field = crate::ui_primitives::filter_pill(
+            "shortcut-search",
+            "shortcut-search-clear",
+            ui,
+            self.shortcut_search_input.clone(),
+            filtering,
+            cx.listener(|this, _: &ClickEvent, _window, cx| {
+                this.clear_shortcut_filters(cx);
+                cx.notify();
+            }),
+        )
+        .flex_1()
+        .min_w_0();
 
         let capture_toggle = squircle_skin(
             div()


### PR DESCRIPTION
> **Draft: needs Linux and Windows verification.** Everything below was
> validated on macOS only.

## What changes
<img width="1450" height="1342" alt="image" src="https://github.com/user-attachments/assets/5312acec-1e92-49aa-ac27-4d670e803751" />

The Shortcuts settings page was a single flat card of 80 rows in registry
order. Finding a binding meant scrolling the whole list, and answering "what
already owns this chord?" was not possible at all.

- **Sections.** Actions declare a `ShortcutGroup` in `keybindings::registry`
  instead of relying on the `ACTIONS` table's order to imply grouping, so the
  sectioning survives sorting, filtering and insertion. Nine sections, each
  collapsible, with an "Expand all" / "Collapse all" control.
- **Text filter.** One field matching the action description *and* the
  keystroke. `format_keystroke` renders Apple HIG glyphs on macOS, where
  "ctrl+shift" would match nothing, so every entry also carries an ASCII
  spelling of its chord (`ascii_key_forms`) covering both readings of GPUI's
  `secondary` plus the usual modifier aliases.
- **Key capture.** A toggle turns the next pressed chord into the filter, which
  is the only way to ask "who owns this key?" without knowing how the chord is
  spelled. The chord is written into the search field, so the user reads back
  exactly what was captured.
- **Reset confirmation.** "Reset to defaults" rewrote every binding with no
  undo on a single click. It now asks first.

Capture has to see the chord before GPUI matches it against the keymap, or
pressing Cmd+Q to find Quit simply quits. `App::intercept_keystrokes` is the
only hook that runs that early: once a binding is dispatched and handled,
`dispatch_key_event` returns without ever calling `finish_dispatch_key_event`,
so no key listener fires at all.

## Bug fixed along the way

Rebinding wrote an unusable chord, on every platform.
`handle_shortcut_recording` persisted `Keystroke::to_string()` - the Display
impl, which is Apple glyphs on macOS and a `ctrl-` / `❖` mix on Linux - not the
`-`-separated syntax `Keystroke::parse` reads back. `save_shortcut_checked`
validates nothing, so a rebind stored a chord no keypress could ever match
while displacing the default it replaced. Now uses `unparse()`, with a test
pinning the round-trip for every default chord.

This predates the rework; making the page usable is what made it reachable.

## Validation actually run

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` - 27 test binaries, no failures
- A code-review pass at xhigh effort; all 15 findings addressed in `60a486c`
- Manual pass on the page: macOS only

`cargo deny` not run - no dependency changed.

## What still needs checking on Linux and Windows

Static audit says the other platforms follow the same path: there is no `#[cfg]`
in the production code, no Windows/Linux equivalent of `MACOS_ONLY_DEFAULTS`
(so the native-chord preference is a no-op there), and `DEFAULTS` holds 76
bindings across 76 distinct actions, so the new one-row-per-action dedupe never
triggers off macOS. That is reasoning, not observation.

Specifically unverified:

- The five `#[cfg(not(target_os = "macos"))]` tests in
  `keybindings/display.rs` have never executed - not locally, not on any macOS
  leg. `Tests (Linux x86_64)` is their first run.
- Chords are far wider off macOS: `⌘⇧⇞` becomes `Ctrl+Shift+PageUp`, so every
  key badge grows. The row is `justify_between` with a `flex_1 min_w_0 truncate`
  description, so it should degrade by truncating the label rather than
  overflowing - but nobody has looked at it on Linux or Windows.
- The toolbar in its confirmation state (field + capture + Cancel + Reset) at
  narrow widths.

No screenshot attached yet; the macOS pass was done locally.

## Note

Branched from `main` at `c9d5ae7`, so this does not include the separate
`feat/settings-modal` work.