### PR TITLE
chore(logging): quiet gpui_macos text_system warnings by default

### DIFF
--- a/src-app/src/main.rs
+++ b/src-app/src/main.rs
@@ -2640,7 +2640,7 @@ fn main() {
     // adds the per-operation diff/git trace - matching the documented
     // "RUST_LOG=info cargo run # with logging" workflow.
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(
-        "warn,wgpu_hal=off,naga=warn,zbus=warn,zbus::proxy=error,tracing::span=warn",
+        "warn,wgpu_hal=off,naga=warn,gpui_macos::text_system=error,zbus=warn,zbus::proxy=error,tracing::span=warn",
     ))
     .init();
 


### PR DESCRIPTION
The macOS text system emits per-glyph fallback warnings that flood the
default `warn` filter during normal rendering. Pin that module to `error`
so the default log stays readable; `RUST_LOG=info` still overrides it.
