### PR TITLE
feat(sidebar): bind tabs to worktrees and add a Customize Sidebar menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ notes are available on the [GitHub Releases](https://github.com/arthjean/paneflo
 
 ## [Unreleased]
 
+### Added
+
+- A tab binds to its own worktree. The "New pane" palette and the tab context
+  menu list the repository's branches: picking one that has no worktree creates
+  it under `<workspace>.worktrees/`, picking one that already has a worktree
+  reuses it, and the pane starts there. An agent that creates a branch from
+  inside a pane now moves that tab alone, where it used to drag every tab of
+  the workspace with it.
+
+- A Customize Sidebar menu on the rail header, with a switch per value: Branch,
+  PR, Diffstat and the indent guide, all off by default. A branch that already
+  has a pull request swaps its glyph for the PR one, in GitHub's state colors.
+  Below them, Expand all / Collapse all, and the fold state of each workspace
+  row now survives a restart.
+
 ## [0.10.0] - 2026-08-31
 
 ### Added

--- a/crates/paneflow-config/src/loader_tests/core_roundtrip.rs
+++ b/crates/paneflow-config/src/loader_tests/core_roundtrip.rs
@@ -28,6 +28,7 @@ fn test_serialization_roundtrip() {
         macos_chrome_material: None,
         unfocused_pane_opacity: None,
         reduce_motion: None,
+        sidebar_show: SidebarShow::default(),
         line_height: None,
         cell_width: None,
         font_family: None,

--- a/crates/paneflow-config/src/loader_tests/session.rs
+++ b/crates/paneflow-config/src/loader_tests/session.rs
@@ -11,7 +11,28 @@ fn make_workspace(title: &str, cwd: &str, tabs: Vec<TabSession>) -> WorkspaceSes
         custom_buttons: vec![],
         expanded_paths: vec![],
         managed_worktrees: vec![],
+        sidebar_collapsed: false,
     }
+}
+
+#[test]
+fn a_folded_rail_row_survives_a_restart_and_an_older_file_stays_unfolded() {
+    // The whole point of folding ten folders is not having to fold them again
+    // on the next launch.
+    let mut ws = make_workspace("main", "/home/user/project", vec![]);
+    ws.sidebar_collapsed = true;
+    let json = serde_json::to_string(&ws).unwrap();
+    assert!(json.contains("sidebar_collapsed"));
+    let back: WorkspaceSession = serde_json::from_str(&json).unwrap();
+    assert!(back.sidebar_collapsed);
+
+    // Unfolded is the default and is not written, so a file from a user who
+    // never folds anything gains no key - and a file written before the field
+    // existed restores unfolded, as the rail has always come up.
+    let unfolded = serde_json::to_string(&make_workspace("main", "/p", vec![])).unwrap();
+    assert!(!unfolded.contains("sidebar_collapsed"));
+    let legacy: WorkspaceSession = serde_json::from_str(r#"{"title":"main","cwd":"/p"}"#).unwrap();
+    assert!(!legacy.sidebar_collapsed);
 }
 
 fn make_surface(cwd: &str) -> SurfaceDefinition {

--- a/crates/paneflow-config/src/loader_tests/session.rs
+++ b/crates/paneflow-config/src/loader_tests/session.rs
@@ -542,11 +542,13 @@ fn test_tab_title_source_survives_a_roundtrip() {
                     title: "sprint 3".to_string(),
                     title_source: Some(TabTitleSource::User),
                     layout: None,
+                    worktree: None,
                 },
                 TabSession {
                     title: "wire up the parser".to_string(),
                     title_source: Some(TabTitleSource::Prompt),
                     layout: None,
+                    worktree: Some("/home/user/project.worktrees/parser".to_string()),
                 },
             ],
         )],

--- a/crates/paneflow-config/src/schema.rs
+++ b/crates/paneflow-config/src/schema.rs
@@ -82,6 +82,12 @@ mod tests {
             macos_chrome_material: Some(true),
             unfocused_pane_opacity: Some(0.7),
             reduce_motion: Some(false),
+            sidebar_show: SidebarShow {
+                branch: Some(true),
+                diffstat: Some(true),
+                pr: Some(true),
+                indent_guide: Some(true),
+            },
             line_height: Some(1.2),
             cell_width: Some(0.6),
             font_family: Some("Geist Mono".to_string()),
@@ -156,6 +162,11 @@ mod tests {
             object_keys(&serialized),
             schema_top_level,
             "top-level PaneFlowConfig and public JSON Schema drifted"
+        );
+        assert_eq!(
+            object_keys(&serialized["sidebar_show"]),
+            object_keys(&schema["properties"]["sidebar_show"]["properties"]),
+            "SidebarShow and public JSON Schema drifted"
         );
         assert_eq!(
             object_keys(&serialized["terminal"]),
@@ -574,6 +585,48 @@ mod tests {
             Some("One Dark"),
             "siblings survive a malformed AI-access toggle"
         );
+    }
+
+    #[test]
+    fn sidebar_show_is_off_by_default_and_tolerant() {
+        // Both lines were taken out of the rail deliberately; an absent key
+        // must leave them out.
+        let cfg: PaneFlowConfig = serde_json::from_str(r#"{}"#).unwrap();
+        assert!(!cfg.sidebar_show.branch_enabled());
+        assert!(!cfg.sidebar_show.diffstat_enabled());
+        assert!(!cfg.sidebar_show.pr_enabled());
+        assert!(!cfg.sidebar_show.indent_guide_enabled());
+        assert!(!cfg.sidebar_show.any_enabled());
+
+        // Each line is its own switch: one on does not turn the other on.
+        let cfg: PaneFlowConfig =
+            serde_json::from_str(r#"{"sidebar_show": {"branch": true}}"#).unwrap();
+        assert!(cfg.sidebar_show.branch_enabled());
+        assert!(!cfg.sidebar_show.diffstat_enabled());
+        assert!(cfg.sidebar_show.any_enabled());
+
+        // The pull-request marker replaces the branch icon rather than adding
+        // a line, so on its own it draws nothing.
+        let cfg: PaneFlowConfig =
+            serde_json::from_str(r#"{"sidebar_show": {"pr": true}}"#).unwrap();
+        assert!(cfg.sidebar_show.pr_enabled());
+        assert!(!cfg.sidebar_show.any_enabled());
+
+        // A malformed field costs that field, never its sibling and never the
+        // rest of the file.
+        let cfg: PaneFlowConfig = serde_json::from_str(
+            r#"{"theme": "One Dark", "sidebar_show": {"branch": "yes", "diffstat": true}}"#,
+        )
+        .unwrap();
+        assert!(!cfg.sidebar_show.branch_enabled());
+        assert!(cfg.sidebar_show.diffstat_enabled());
+        assert_eq!(cfg.theme.as_deref(), Some("One Dark"));
+
+        // A wholly malformed object costs the setting, not the file.
+        let cfg: PaneFlowConfig =
+            serde_json::from_str(r#"{"theme": "One Dark", "sidebar_show": "detailed"}"#).unwrap();
+        assert!(!cfg.sidebar_show.any_enabled());
+        assert_eq!(cfg.theme.as_deref(), Some("One Dark"));
     }
 
     #[test]

--- a/crates/paneflow-config/src/schema/config.rs
+++ b/crates/paneflow-config/src/schema/config.rs
@@ -59,6 +59,10 @@ pub struct PaneFlowConfig {
     /// through `App::set_reduce_motion`, so it hot-reloads.
     #[serde(default, deserialize_with = "lenient_value_or_default")]
     pub reduce_motion: Option<bool>,
+    /// What the workspaces rail shows beyond a row's name. See [`SidebarShow`].
+    /// Everything off is the rail as it ships.
+    #[serde(default, deserialize_with = "lenient_value_or_default")]
+    pub sidebar_show: SidebarShow,
     /// Terminal line height multiplier (default: 1.2, valid range: 1.0-2.5).
     #[serde(default, deserialize_with = "lenient_value_or_default")]
     pub line_height: Option<f32>,
@@ -294,6 +298,73 @@ pub struct PaneFlowConfig {
         deserialize_with = "lenient_value_or_default"
     )]
     pub tool_permissions: HashMap<String, ToolPermissionsEntry>,
+}
+
+/// What a tab row of the rail says beyond its name and its activity.
+///
+/// `4f8c982` took the git branch and the diffstat out of the rail because
+/// "both crowded the row for little signal, and the Diff view is where change
+/// counts belong". That holds for a workspace row - one folder, one branch, a
+/// near-constant line - and stops holding on a tab row, where a tab bound to a
+/// git worktree (discussion #41) is told apart from its siblings by exactly
+/// these two values. So they come back here, per line, opt-in, and on the tab
+/// rows rather than on the folder above them.
+///
+/// Both off is the rail as it ships: no second line is built at all, so a row
+/// keeps its geometry rather than reserving a height it does not use.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SidebarShow {
+    /// Show a session tab's branch: its bound worktree's, or its workspace's
+    /// when the tab is unbound. `None` is `false`.
+    #[serde(default, deserialize_with = "lenient_value_or_default")]
+    pub branch: Option<bool>,
+    /// Show that same checkout's insertion and deletion counts. `None` is
+    /// `false`.
+    #[serde(default, deserialize_with = "lenient_value_or_default")]
+    pub diffstat: Option<bool>,
+    /// Mark a branch that already has a pull request: its icon becomes the
+    /// pull-request glyph, in GitHub's color for the request's state. Needs
+    /// `gh`, and answers for GitHub remotes only. `None` is `false`.
+    #[serde(default, deserialize_with = "lenient_value_or_default")]
+    pub pr: Option<bool>,
+    /// Draw a hairline under a workspace's folder icon, running down its tab
+    /// rows, the way a tree view ties children to their parent. `None` is
+    /// `false`.
+    #[serde(default, deserialize_with = "lenient_value_or_default")]
+    pub indent_guide: Option<bool>,
+}
+
+impl SidebarShow {
+    /// Whether the branch line is on. Absent means off.
+    pub fn branch_enabled(&self) -> bool {
+        self.branch.unwrap_or(false)
+    }
+
+    /// Whether the diffstat is on. Absent means off.
+    pub fn diffstat_enabled(&self) -> bool {
+        self.diffstat.unwrap_or(false)
+    }
+
+    /// Whether the pull-request marker is on. Absent means off.
+    pub fn pr_enabled(&self) -> bool {
+        self.pr.unwrap_or(false)
+    }
+
+    /// Whether the rail draws its indent hairline. Absent means off.
+    pub fn indent_guide_enabled(&self) -> bool {
+        self.indent_guide.unwrap_or(false)
+    }
+
+    /// Whether a tab row draws a second line at all.
+    ///
+    /// Neither the pull-request marker nor the indent guide is in here: the
+    /// first replaces the branch icon rather than adding anything, and the
+    /// second draws beside the row instead of inside it. On their own, neither
+    /// gives a row a second line.
+    pub fn any_enabled(&self) -> bool {
+        self.branch_enabled() || self.diffstat_enabled()
+    }
 }
 
 impl PaneFlowConfig {

--- a/crates/paneflow-config/src/schema/session.rs
+++ b/crates/paneflow-config/src/schema/session.rs
@@ -327,6 +327,13 @@ pub struct WorkspaceSession {
     /// Additive + optional like `expanded_paths`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub managed_worktrees: Vec<ManagedWorktreeDef>,
+    /// Whether the rail row of this workspace was unfolded at save time.
+    /// Additive and optional: absent in older files and, being written only
+    /// when folded, absent for every workspace of a user who never folds one.
+    /// The rail has always come up unfolded, and that stays the answer when
+    /// the key is missing.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub sidebar_collapsed: bool,
 }
 
 /// Migrate a v1 `session.json` in place to the v2 tab shape (US-018).

--- a/crates/paneflow-config/src/schema/session.rs
+++ b/crates/paneflow-config/src/schema/session.rs
@@ -254,6 +254,16 @@ pub struct TabSession {
     /// Pane layout tree for this tab. `None` = the tab holds no pane.
     #[serde(default)]
     pub layout: Option<LayoutNode>,
+    /// Absolute path of the git worktree this tab is bound to (discussion #41),
+    /// or `None` for an unbound tab.
+    ///
+    /// Additive and defaulted, so it needs no schema version bump: a v2 file
+    /// written before this field parses with `None`, and an older Paneflow
+    /// reading a file that has it ignores the key rather than failing (no
+    /// `deny_unknown_fields` anywhere in this schema). A path that no longer
+    /// exists at restore is dropped, not resurrected.
+    #[serde(default)]
+    pub worktree: Option<String>,
 }
 
 impl TabSession {
@@ -268,6 +278,7 @@ impl TabSession {
             title: String::new(),
             title_source: Some(TabTitleSource::Preset),
             layout: Some(layout),
+            worktree: None,
         }
     }
 }
@@ -403,6 +414,8 @@ fn demote_panes_to_focused_surface(node: &mut LayoutNode, promoted: &mut Vec<Tab
                     layout: Some(LayoutNode::Pane {
                         surfaces: vec![surface],
                     }),
+                    // A v1 file predates tab worktrees by definition.
+                    worktree: None,
                 });
             }
         }

--- a/docs/user/configuration/schema.md
+++ b/docs/user/configuration/schema.md
@@ -39,6 +39,7 @@ Unknown top-level keys are ignored by the runtime. The schema uses
 | `cell_width` | number or null | `0.6` | Multiplier, range `0.3` to `2.0`. |
 | `unfocused_pane_opacity` | number or null | `0.7` | Opacity of panes without focus when a workspace has more than one pane, range `0.15` to `1.0`. `1.0` disables the dim. |
 | `reduce_motion` | boolean or null | `false` | Minimize non-essential interface motion: hover transitions settle instantly and decorative animations render a static frame. |
+| `sidebar_show` | object or null | all off | What a session tab row shows beyond its name: `branch` (boolean) adds its git branch, `diffstat` (boolean) adds its insertion and deletion counts, `pr` (boolean) turns the branch icon into a pull-request glyph colored by the request's state when one exists, `indent_guide` (boolean) draws a hairline under a workspace's folder icon down its tab rows. The first two read the tab's bound worktree, or its workspace's checkout when the tab is unbound; `pr` needs the `gh` CLI and answers for GitHub remotes only. Toggled from the rail's Customize Sidebar menu. |
 | `window_decorations` | string or null | `client` | `client` for Paneflow chrome, `server` for OS/compositor chrome. Read at startup. |
 | `window_backdrop` | string or null | `auto` | `auto`, `mica`, `blurred`, `acrylic`, `transparent`, `opaque`, or `off`. Read at startup. |
 | `windows_terminal_material` | boolean or null | `false` | Windows-only terminal background transparency for Mica/blur materials. |
@@ -260,6 +261,12 @@ unconditionally.
   "cell_width": 0.6,
   "unfocused_pane_opacity": 0.7,
   "reduce_motion": false,
+  "sidebar_show": {
+    "branch": false,
+    "diffstat": false,
+    "pr": false,
+    "indent_guide": false
+  },
   "window_decorations": "client",
   "window_backdrop": "auto",
   "windows_terminal_material": false,

--- a/schemas/paneflow.schema.json
+++ b/schemas/paneflow.schema.json
@@ -95,6 +95,33 @@
       "description": "Minimize non-essential interface motion: hover transitions settle instantly and decorative animations render a static frame. Default false.",
       "default": false
     },
+    "sidebar_show": {
+      "type": ["object", "null"],
+      "description": "What the workspaces rail shows beyond a row's name. Everything off is the default rail.",
+      "additionalProperties": false,
+      "properties": {
+        "branch": {
+          "type": ["boolean", "null"],
+          "description": "Show a session tab's git branch: its bound worktree's, or its workspace's when the tab is unbound. Default false.",
+          "default": false
+        },
+        "diffstat": {
+          "type": ["boolean", "null"],
+          "description": "Show that same checkout's insertion and deletion counts. Default false.",
+          "default": false
+        },
+        "pr": {
+          "type": ["boolean", "null"],
+          "description": "Mark a branch that already has a pull request: its icon becomes the pull-request glyph, colored by the request's state. Needs the 'gh' CLI, and answers for GitHub remotes only. Default false.",
+          "default": false
+        },
+        "indent_guide": {
+          "type": ["boolean", "null"],
+          "description": "Draw a hairline under a workspace's folder icon, running down its tab rows. Default false.",
+          "default": false
+        }
+      }
+    },
     "window_decorations": {
       "type": ["string", "null"],
       "description": "Window decoration mode. 'client' = client-side decorations (custom title bar). 'server' = server-side decorations (compositor-drawn). Read once at startup; changes require a restart.",

--- a/src-app/assets/icons/filter-2.svg
+++ b/src-app/assets/icons/filter-2.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-filter-2"><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M4 6h16" /><path d="M6 12h12" /><path d="M9 18h6" /></svg>

--- a/src-app/src/app/bootstrap.rs
+++ b/src-app/src/app/bootstrap.rs
@@ -269,6 +269,12 @@ impl PaneFlowApp {
                         // Collect CWDs of affected workspaces (main thread)
                         let cwds = cx.update(|cx| {
                             this.update(cx, |app: &mut Self, _cx: &mut Context<Self>| {
+                                // A bound tab's worktree is probed with its
+                                // workspace: a linked worktree's index lives
+                                // under the main repository's git dir, which is
+                                // the one being watched, so the event that
+                                // fires for the workspace is the same event
+                                // that means the tab's counts moved.
                                 app.workspaces
                                     .iter()
                                     .filter(|ws| {
@@ -276,7 +282,13 @@ impl PaneFlowApp {
                                             .as_ref()
                                             .is_some_and(|gd| affected_dirs.contains(gd))
                                     })
-                                    .map(|ws| ws.cwd.clone())
+                                    .flat_map(|ws| {
+                                        std::iter::once(ws.cwd.clone())
+                                            .chain(ws.bound_tab_worktrees())
+                                    })
+                                    .filter(|cwd| !cwd.is_empty())
+                                    .collect::<std::collections::BTreeSet<String>>()
+                                    .into_iter()
                                     .collect::<Vec<String>>()
                             })
                         });
@@ -505,14 +517,10 @@ impl PaneFlowApp {
                     // one subprocess per tick.
                     let cwds = cx.update(|cx| {
                         this.update(cx, |app: &mut Self, _cx: &mut Context<Self>| {
-                            let mut seen = std::collections::HashSet::new();
-                            let mut out = Vec::new();
-                            for ws in &app.workspaces {
-                                if seen.insert(ws.cwd.clone()) {
-                                    out.push(ws.cwd.clone());
-                                }
-                            }
-                            out
+                            // Workspace roots plus every bound tab's worktree,
+                            // deduplicated: two tabs on one worktree cost one
+                            // subprocess per tick, not two.
+                            app.git_probe_cwds()
                         })
                     });
                     let cwds = match cwds {
@@ -860,6 +868,8 @@ impl PaneFlowApp {
             font_search: String::new(),
             theme_mode,
             workspace_menu_open: None,
+            worktree_states: crate::app::tab_worktree::WorktreeStates::default(),
+            branch_checkout_pending: None,
             tab_menu_open: None,
             pane_menu_open: None,
             pending_pane_focus: None,

--- a/src-app/src/app/bootstrap.rs
+++ b/src-app/src/app/bootstrap.rs
@@ -560,6 +560,11 @@ impl PaneFlowApp {
                             if changed && !refreshed_diff {
                                 cx.notify();
                             }
+                            // Same tick as the git state, and gated on the
+                            // switch: the branches are already resolved here,
+                            // and a lookup only fires once its cache entry has
+                            // aged out.
+                            app.refresh_pull_requests(cx);
                         })
                     });
                     if apply.is_err() {
@@ -870,6 +875,9 @@ impl PaneFlowApp {
             workspace_menu_open: None,
             worktree_states: crate::app::tab_worktree::WorktreeStates::default(),
             branch_checkout_pending: None,
+            pr_states: crate::app::pull_request::PrStates::default(),
+            sidebar_customize_menu_open: false,
+            sidebar_show_submenu_open: false,
             tab_menu_open: None,
             pane_menu_open: None,
             pending_pane_focus: None,

--- a/src-app/src/app/cli_diff_dock.rs
+++ b/src-app/src/app/cli_diff_dock.rs
@@ -172,9 +172,7 @@ impl PaneFlowApp {
             // Reopening on the snapshot's own folder, not the workspace root:
             // the two are the same today, and asking the data keeps the warm
             // snapshot valid if a dock is ever opened on a subfolder.
-            let cwd = cwd
-                .or_else(|| self.active_workspace().map(|ws| ws.cwd.clone()))
-                .unwrap_or_default();
+            let cwd = cwd.or_else(|| self.active_checkout()).unwrap_or_default();
             self.open_diff_dock_panel(cwd, cx);
         }
     }

--- a/src-app/src/app/diff_view_helpers.rs
+++ b/src-app/src/app/diff_view_helpers.rs
@@ -76,9 +76,23 @@ impl PaneFlowApp {
         self.workspaces
             .get(self.active_idx)
             .map(|ws| {
+                // Discussion #41: the seed follows the active tab. A tab bound
+                // to a worktree reviews that checkout, so switching tab
+                // switches what Project scope shows - the workspace root is
+                // only the answer for an unbound tab.
+                let tab = ws.active_tab();
+                let (path, branch) = match tab.worktree.as_ref() {
+                    Some(worktree) => (
+                        worktree.clone(),
+                        self.tab_checkout_git(tab)
+                            .map(|git| git.branch.clone())
+                            .unwrap_or_default(),
+                    ),
+                    None => (ws.worktree_root.clone(), ws.git_branch.clone()),
+                };
                 vec![crate::diff::DiffWorktree {
-                    path: ws.worktree_root.clone(),
-                    branch: ws.git_branch.clone(),
+                    path,
+                    branch,
                     workspace_id: Some(ws.id),
                 }]
             })

--- a/src-app/src/app/event_handlers.rs
+++ b/src-app/src/app/event_handlers.rs
@@ -204,9 +204,14 @@ fn keep_session_after_surface_purge(
 ///   which is the conservative answer for an agent that backgrounded itself.
 ///
 /// Synthetic keys (legacy no-pid frames) cannot be probed, so the prompt is
-/// the only evidence available and they are reaped.
+/// the only evidence available and they are reaped. `surface_child_pid` is
+/// reaped on the same terms: a session keyed on the pane's own shell is the
+/// last-resort identity a terminal-sourced observation falls back to, and
+/// probing THAT pid asks whether the shell printing this very prompt is
+/// alive, which it always is.
 fn keep_session_at_shell_prompt(
     prompt_surface_id: u64,
+    surface_child_pid: u32,
     pid: u32,
     session: &ai_types::AgentSession,
 ) -> bool {
@@ -214,7 +219,42 @@ fn keep_session_at_shell_prompt(
         return true;
     }
     session.state == ai_types::AgentState::Errored
-        || (pid <= i32::MAX as u32 && pid_matches(pid, session.proc_start))
+        || (pid != surface_child_pid
+            && pid <= i32::MAX as u32
+            && pid_matches(pid, session.proc_start))
+}
+
+/// Retention rule when a pane's process scan no longer sees an agent in its
+/// PTY subtree.
+///
+/// The scan is PID-authoritative and re-runs on every activity burst, which
+/// makes it the one "the agent is gone" signal that survives a machine with
+/// no hooks, and it fires whether or not the shell publishes OSC 133 prompt
+/// marks. Three exceptions keep the existing contracts intact:
+///
+/// - an `Errored` row stays sticky until its pane closes, the same rule
+///   [`keep_session_at_shell_prompt`] applies;
+/// - a real PID still alive with its pinned start time keeps its row, so a
+///   scan that missed the process (or a platform whose scanner is a stub)
+///   can never reap a live agent;
+/// - a session keyed on the pane's OWN shell is the case this rule exists
+///   for. That key is the last-resort identity a terminal-sourced
+///   observation falls back to when nothing told it the agent's PID; it
+///   outlives every agent the pane runs, so probing it answers "alive"
+///   forever and the scan is the only evidence available.
+fn keep_session_without_agent_in_pane(
+    surface_id: u64,
+    surface_child_pid: u32,
+    pid: u32,
+    session: &ai_types::AgentSession,
+) -> bool {
+    if session.surface_id != Some(surface_id) {
+        return true;
+    }
+    session.state == ai_types::AgentState::Errored
+        || (pid != surface_child_pid
+            && pid <= i32::MAX as u32
+            && pid_matches(pid, session.proc_start))
 }
 
 fn stale_sweep_keeps_without_pid_probe(
@@ -569,16 +609,19 @@ impl PaneFlowApp {
                 self.open_sessions_sidebar_for_pane(&pane, None, cx);
             }
             pane::PaneEvent::ToggleDiffDock => {
-                // The dock diffs the pane's *workspace folder*, not the shell's
-                // current directory: the folder is the unit the git pipeline
-                // operates on.
+                // The dock diffs the pane's *checkout*, not the shell's current
+                // directory: the checkout is the unit the git pipeline operates
+                // on. For a tab bound to a worktree (discussion #41) that is
+                // the tab's worktree, so two tabs of one workspace diff two
+                // different branches instead of both reporting the repository
+                // root.
                 let owner_id = pane.read(cx).workspace_id;
-                let Some(cwd) = self
-                    .workspaces
-                    .iter()
-                    .find(|ws| ws.id == owner_id)
-                    .map(|ws| ws.cwd.clone())
-                else {
+                let Some(cwd) = self.checkout_for_pane(&pane).or_else(|| {
+                    self.workspaces
+                        .iter()
+                        .find(|ws| ws.id == owner_id)
+                        .map(|ws| ws.cwd.clone())
+                }) else {
                     return;
                 };
                 self.toggle_cli_diff_dock(cwd, cx);
@@ -923,7 +966,8 @@ impl PaneFlowApp {
                 // of waiting <=30 s for the PID sweep, and cover the agents
                 // the hooks never report on (shim SIGKILLed, CLI launched
                 // without hook integration at all).
-                self.reap_sessions_at_shell_prompt(terminal.entity_id().as_u64(), cx);
+                let child_pid = terminal.read(cx).terminal.child_pid;
+                self.reap_sessions_at_shell_prompt(terminal.entity_id().as_u64(), child_pid, cx);
             }
             terminal::TerminalEvent::ChildExited => {
                 // The Pane's own subscription closes the tab; here we drop
@@ -1031,6 +1075,7 @@ impl PaneFlowApp {
     pub(crate) fn reap_sessions_at_shell_prompt(
         &mut self,
         surface_id: u64,
+        surface_child_pid: u32,
         cx: &mut Context<Self>,
     ) {
         let mut changed = false;
@@ -1039,8 +1084,47 @@ impl PaneFlowApp {
                 continue;
             }
             let before = ws.agent_sessions.len();
-            ws.agent_sessions
-                .retain(|&pid, session| keep_session_at_shell_prompt(surface_id, pid, session));
+            ws.agent_sessions.retain(|&pid, session| {
+                keep_session_at_shell_prompt(surface_id, surface_child_pid, pid, session)
+            });
+            if ws.agent_sessions.len() < before {
+                changed = true;
+            }
+        }
+        if changed {
+            self.sync_attention(cx);
+            self.agent_sessions_changed(cx);
+            cx.notify();
+        }
+    }
+
+    /// Reap the agent rows a surface still carries once its process scan
+    /// stops seeing an agent in the pane.
+    ///
+    /// Event-driven complement to [`Self::reap_sessions_at_shell_prompt`],
+    /// for the panes that never publish a prompt mark: same post-mutation
+    /// trio, retention decided by the pure
+    /// [`keep_session_without_agent_in_pane`]. `agentless` pairs each surface
+    /// whose identity the scan just cleared with that surface's PTY child.
+    pub(crate) fn reap_sessions_without_agent(
+        &mut self,
+        agentless: &[(u64, u32)],
+        cx: &mut Context<Self>,
+    ) {
+        if agentless.is_empty() {
+            return;
+        }
+        let mut changed = false;
+        for ws in &mut self.workspaces {
+            if ws.agent_sessions.is_empty() {
+                continue;
+            }
+            let before = ws.agent_sessions.len();
+            ws.agent_sessions.retain(|&pid, session| {
+                agentless.iter().all(|&(surface_id, child_pid)| {
+                    keep_session_without_agent_in_pane(surface_id, child_pid, pid, session)
+                })
+            });
             if ws.agent_sessions.len() < before {
                 changed = true;
             }
@@ -1446,6 +1530,11 @@ impl PaneFlowApp {
             }
         }
 
+        // Surfaces whose agent identity this deposit clears, paired with their
+        // PTY child. An agent that leaves its pane takes its sidebar row with
+        // it, and on a machine with no hooks this scan is what says so.
+        let mut agentless: Vec<(u64, u32)> = Vec::new();
+
         for pane in &leaves {
             let terminals: Vec<gpui::Entity<crate::terminal::TerminalView>> =
                 pane.read(cx).terminals().cloned().collect();
@@ -1481,6 +1570,9 @@ impl PaneFlowApp {
                             // The live scan owns the value from here on - this
                             // both confirms a declared or restored "last known"
                             // pill and clears a stale one (US-013).
+                            if agent.is_none() && t.detected_agent.is_some() {
+                                agentless.push((tid, t.child_pid));
+                            }
                             t.detected_agent = agent;
                             t.agent_confirmed = true;
                             pane_changed = true;
@@ -1520,6 +1612,8 @@ impl PaneFlowApp {
             }
         }
 
+        self.reap_sessions_without_agent(&agentless, cx);
+
         if changed {
             cx.notify();
         }
@@ -1533,19 +1627,29 @@ impl PaneFlowApp {
         new_cwd: &str,
         cx: &mut Context<Self>,
     ) {
-        // Find workspace where this terminal is the active tab in any pane.
+        // Find the tab holding this terminal, in any workspace. Every tab, not
+        // just the active one: a pane that walks into another checkout gives
+        // its tab an identity whether or not you are looking at it.
         // US-020: skip markdown panes - they have no active terminal, so the
         // identity check via `active_terminal_opt` returns None for them.
-        let ws_idx = self.workspaces.iter().position(|ws| {
-            ws.active_tab().root.as_ref().is_some_and(|root| {
-                root.any_leaf(&mut |pane| {
-                    pane.read(cx)
-                        .active_terminal_opt()
-                        .is_some_and(|t| *t == *terminal)
+        let located = self.workspaces.iter().enumerate().find_map(|(ws_idx, ws)| {
+            ws.tabs()
+                .iter()
+                .position(|tab| {
+                    tab.root.as_ref().is_some_and(|root| {
+                        root.any_leaf(&mut |pane| {
+                            pane.read(cx)
+                                .active_terminal_opt()
+                                .is_some_and(|t| *t == *terminal)
+                        })
+                    })
                 })
-            })
+                .map(|tab_idx| (ws_idx, tab_idx))
         });
-        let Some(ws_idx) = ws_idx else { return };
+        let Some((ws_idx, tab_idx)) = located else {
+            return;
+        };
+        let is_active_tab = self.workspaces[ws_idx].active_tab_idx() == tab_idx;
 
         if self.workspaces[ws_idx].cwd == new_cwd {
             return;
@@ -1559,6 +1663,9 @@ impl PaneFlowApp {
         // Re-resolve the index by identity after the await - model:
         // `run_port_scan` / `spawn_initial_git_stats`.
         let ws_id = self.workspaces[ws_idx].id;
+        let tab_id = self.workspaces[ws_idx].tabs()[tab_idx].id;
+        let ws_repo_root = self.workspaces[ws_idx].repo_root.clone();
+        let ws_worktree_root = self.workspaces[ws_idx].worktree_root.clone();
 
         let new_cwd_owned = new_cwd.to_string();
 
@@ -1566,13 +1673,25 @@ impl PaneFlowApp {
         cx.spawn({
             let new_cwd = new_cwd_owned.clone();
             async move |this: gpui::WeakEntity<Self>, cx: &mut gpui::AsyncApp| {
-                let (git_dir, branch, is_repo, stats) = smol::unblock({
+                let (git_dir, branch, is_repo, stats, checkout) = smol::unblock({
                     let cwd = new_cwd.clone();
                     move || {
                         let git_dir = crate::workspace::find_git_dir(&cwd);
                         let (branch, is_repo) = crate::workspace::detect_branch(&cwd);
                         let stats = crate::workspace::GitDiffStats::from_cwd(&cwd);
-                        (git_dir, branch, is_repo, stats)
+                        // Which checkout of which repository the pane is now
+                        // in. All file reads under `.git`, no subprocess.
+                        let checkout = git_dir.as_deref().map(|dir| {
+                            let (repo_root, is_worktree) = crate::workspace::resolve_repo_root(dir);
+                            let root = crate::workspace::resolve_worktree_root(
+                                &cwd,
+                                Some(dir),
+                                repo_root.as_deref(),
+                                is_worktree,
+                            );
+                            (repo_root, root)
+                        });
+                        (git_dir, branch, is_repo, stats, checkout)
                     }
                 })
                 .await;
@@ -1585,6 +1704,42 @@ impl PaneFlowApp {
                         else {
                             return;
                         };
+                        // The pane walked into another checkout of the same
+                        // repository - an agent that made itself a worktree,
+                        // typically. That is this TAB's identity now, and it
+                        // must not be written onto the workspace: the other
+                        // tabs still work in the repository's own checkout,
+                        // and until now this branch landed on `ws.cwd`'s git
+                        // state, showing every one of them a branch none of
+                        // them was on.
+                        if let Some((repo_root, checkout)) = checkout
+                            && repo_root.is_some()
+                            && repo_root == ws_repo_root
+                            && checkout != ws_worktree_root
+                        {
+                            if let Some((ws_idx, tab_idx)) = app.tab_position(ws_id, tab_id) {
+                                app.set_tab_worktree(ws_idx, tab_idx, Some(checkout.clone()), cx);
+                            }
+                            let key = checkout.to_string_lossy().into_owned();
+                            if app.worktree_states.set_checkout(
+                                &key,
+                                crate::app::tab_worktree::CheckoutGit {
+                                    branch,
+                                    is_repo,
+                                    stats,
+                                },
+                            ) {
+                                cx.notify();
+                            }
+                            return;
+                        }
+                        // A `cd` inside a background tab says nothing about
+                        // the workspace's own checkout: only the tab you are
+                        // looking at moves the workspace's git state, as it
+                        // did before tabs had an identity of their own.
+                        if !is_active_tab {
+                            return;
+                        }
                         // Unwatch old git dir
                         let old_git_dir = app.workspaces[ws_idx].git_dir.clone();
                         if let Some(ref dir) = old_git_dir {
@@ -1665,8 +1820,9 @@ impl PaneFlowApp {
 mod tests {
     use super::{
         announced_port_conflicts, declaration_survives_scan, keep_session_after_surface_purge,
-        keep_session_at_shell_prompt, merge_scan_workspace_state, merge_service_label,
-        parse_proc_stat_starttime, port_ownership, stale_sweep_keeps_without_pid_probe,
+        keep_session_at_shell_prompt, keep_session_without_agent_in_pane,
+        merge_scan_workspace_state, merge_service_label, parse_proc_stat_starttime, port_ownership,
+        stale_sweep_keeps_without_pid_probe,
     };
     use crate::agent_launcher::TerminalAgent;
     use crate::ai_types::{AgentSession, AgentState};
@@ -1700,17 +1856,23 @@ mod tests {
     fn shell_prompt_reaps_the_surface_it_fired_on() {
         // A synthetic key can't be probed, so the prompt is the only evidence
         // available and the row goes.
+        const SHELL: u32 = 4242;
         let mut thinking = AgentSession::new(TerminalAgent::ClaudeCode, AgentState::Thinking);
         thinking.surface_id = Some(7);
-        assert!(!keep_session_at_shell_prompt(7, u32::MAX, &thinking));
+        assert!(!keep_session_at_shell_prompt(7, SHELL, u32::MAX, &thinking));
         // Another pane's prompt says nothing about this session.
-        assert!(keep_session_at_shell_prompt(8, u32::MAX, &thinking));
+        assert!(keep_session_at_shell_prompt(8, SHELL, u32::MAX, &thinking));
+
+        // A row keyed on the pane's own shell goes with the prompt too: that
+        // pid outlives every agent the pane runs, so probing it proves
+        // nothing.
+        assert!(!keep_session_at_shell_prompt(7, SHELL, SHELL, &thinking));
 
         // An Errored row stays sticky until its pane closes: the shell prints
         // its prompt the instant the agent crashes.
         let mut errored = AgentSession::new(TerminalAgent::ClaudeCode, AgentState::Errored);
         errored.surface_id = Some(7);
-        assert!(keep_session_at_shell_prompt(7, u32::MAX, &errored));
+        assert!(keep_session_at_shell_prompt(7, SHELL, u32::MAX, &errored));
 
         // A live real PID with a matching start time survives - the current
         // process is our own, so the probe is guaranteed to answer "alive".
@@ -1718,7 +1880,57 @@ mod tests {
         backgrounded.surface_id = Some(7);
         let own_pid = std::process::id();
         backgrounded.proc_start = super::pid_start_time(own_pid);
-        assert!(keep_session_at_shell_prompt(7, own_pid, &backgrounded));
+        assert!(keep_session_at_shell_prompt(
+            7,
+            SHELL,
+            own_pid,
+            &backgrounded
+        ));
+    }
+
+    #[test]
+    fn a_pane_that_lost_its_agent_drops_the_row_keyed_on_its_own_shell() {
+        // The failure this prevents: quitting Claude Code leaves the pane's
+        // shell alive, so a row keyed on that shell probes "alive" forever
+        // and the attention bell never clears.
+        const SHELL: u32 = 4242;
+        let mut waiting = AgentSession::new(TerminalAgent::ClaudeCode, AgentState::WaitingForInput);
+        waiting.surface_id = Some(7);
+        assert!(!keep_session_without_agent_in_pane(
+            7, SHELL, SHELL, &waiting
+        ));
+        // Another pane's scan says nothing about this session.
+        assert!(keep_session_without_agent_in_pane(
+            8, SHELL, SHELL, &waiting
+        ));
+
+        // A synthetic key cannot be probed either, so the scan decides.
+        assert!(!keep_session_without_agent_in_pane(
+            7,
+            SHELL,
+            u32::MAX,
+            &waiting
+        ));
+
+        // An Errored row stays sticky until its pane closes.
+        let mut errored = AgentSession::new(TerminalAgent::ClaudeCode, AgentState::Errored);
+        errored.surface_id = Some(7);
+        assert!(keep_session_without_agent_in_pane(
+            7, SHELL, SHELL, &errored
+        ));
+
+        // A live agent PID survives a scan that failed to see it - our own
+        // process is the one probe guaranteed to answer "alive".
+        let mut backgrounded = AgentSession::new(TerminalAgent::Codex, AgentState::Thinking);
+        backgrounded.surface_id = Some(7);
+        let own_pid = std::process::id();
+        backgrounded.proc_start = super::pid_start_time(own_pid);
+        assert!(keep_session_without_agent_in_pane(
+            7,
+            SHELL,
+            own_pid,
+            &backgrounded
+        ));
     }
 
     #[test]

--- a/src-app/src/app/ipc_handler.rs
+++ b/src-app/src/app/ipc_handler.rs
@@ -184,6 +184,46 @@ pub(crate) fn build_up_layout(
     }
 }
 
+/// Split `workspace.up`'s panes into one tab per git worktree.
+///
+/// Returns each tab's worktree (`None` for the workspace's own checkout) with
+/// the pane indices it holds, in display order: the unbound panes first, then
+/// one tab per distinct worktree in first-appearance order.
+///
+/// This is the fix for the confusion discussion #41 describes, and Paneflow's
+/// own orchestration path was producing it: `up` accepts a per-pane
+/// `worktree = "branch"`, creates each checkout, then stacked every pane into a
+/// single tab where two worktrees sat side by side, visually identical. One tab
+/// per worktree makes switching checkout a deliberate gesture with a visible
+/// target.
+///
+/// A batch that declares no worktree at all yields exactly one group holding
+/// every pane in order - byte-for-byte the layout `up` has always built.
+pub(crate) fn group_up_panes_by_worktree(
+    worktrees: &[Option<String>],
+) -> Vec<(Option<String>, Vec<usize>)> {
+    let mut unbound: Vec<usize> = Vec::new();
+    // Insertion-ordered rather than a map: the tab order must follow the order
+    // the panes were declared in, which is the order the conductor wrote them.
+    let mut bound: Vec<(String, Vec<usize>)> = Vec::new();
+    for (idx, worktree) in worktrees.iter().enumerate() {
+        match worktree {
+            None => unbound.push(idx),
+            Some(path) => match bound.iter_mut().find(|(known, _)| known == path) {
+                Some((_, panes)) => panes.push(idx),
+                None => bound.push((path.clone(), vec![idx])),
+            },
+        }
+    }
+
+    let mut groups: Vec<(Option<String>, Vec<usize>)> = Vec::with_capacity(bound.len() + 1);
+    if !unbound.is_empty() {
+        groups.push((None, unbound));
+    }
+    groups.extend(bound.into_iter().map(|(path, panes)| (Some(path), panes)));
+    groups
+}
+
 fn fire_turn_end_notification(
     agent: TerminalAgent,
     workspace_title: &str,
@@ -1820,10 +1860,19 @@ impl PaneFlowApp {
         // these panes - the workspace records ownership so close tears them
         // down (US-009) and session restore keeps the record across a crash.
         let mut managed_worktrees: Vec<crate::workspace::worktree::ManagedWorktree> = Vec::new();
+        // Which worktree each pane belongs to, by pane index. Kept parallel to
+        // `planned` rather than folded into the flat ownership list above: the
+        // tab split below needs the pane-to-checkout mapping, and reading it
+        // back from cwd prefixes would guess where the spec already states it.
+        let mut pane_worktrees: Vec<Option<String>> = Vec::with_capacity(pane_specs.len());
         let mut planned: Vec<PlannedPane> = Vec::with_capacity(pane_specs.len());
         for (i, spec) in pane_specs.iter().enumerate() {
-            if let Some(mw) = parse_managed_worktree(spec.get("managed_worktree")) {
-                managed_worktrees.push(mw);
+            match parse_managed_worktree(spec.get("managed_worktree")) {
+                Some(mw) => {
+                    pane_worktrees.push(Some(mw.path.to_string_lossy().into_owned()));
+                    managed_worktrees.push(mw);
+                }
+                None => pane_worktrees.push(None),
             }
             match parse_workspace_pane_plan(spec) {
                 Ok(plan) => planned.push(plan),
@@ -1886,15 +1935,56 @@ impl PaneFlowApp {
         }
 
         let focus_idx = planned.iter().position(|p| p.focus).unwrap_or(0);
-        let Some(tree) = build_up_layout(preset, panes, focus_idx) else {
-            return JsonRpcError::invalid_params("could not build layout from panes").into_value();
-        };
 
-        let ws_cwd = planned
+        // Discussion #41: one tab per worktree. With no worktree declared this
+        // is a single group holding every pane, so the layout is the one `up`
+        // has always built.
+        let groups = group_up_panes_by_worktree(&pane_worktrees);
+        let mut tabs: Vec<crate::workspace::Tab> = Vec::with_capacity(groups.len());
+        let mut active_tab = 0;
+        for (tab_idx, (worktree, pane_idxs)) in groups.iter().enumerate() {
+            if pane_idxs.contains(&focus_idx) {
+                active_tab = tab_idx;
+            }
+            let group_panes: Vec<Entity<Pane>> =
+                pane_idxs.iter().map(|i| panes[*i].clone()).collect();
+            // The focused pane's position WITHIN this tab: `main_vertical`
+            // promotes it, and a global index would promote the wrong pane.
+            let local_focus = pane_idxs.iter().position(|i| *i == focus_idx).unwrap_or(0);
+            let Some(tree) = build_up_layout(preset, group_panes, local_focus) else {
+                return JsonRpcError::invalid_params("could not build layout from panes")
+                    .into_value();
+            };
+            // A worktree tab is named by its branch, at the weakest title rank
+            // so the agent's own session title still replaces it.
+            let title = worktree
+                .as_ref()
+                .and_then(|path| {
+                    managed_worktrees
+                        .iter()
+                        .find(|mw| mw.path.to_string_lossy() == path.as_str())
+                        .map(|mw| mw.branch.clone())
+                })
+                .unwrap_or_default();
+            tabs.push(crate::workspace::Tab::restored(
+                title,
+                paneflow_config::schema::TabTitleSource::Preset,
+                Some(tree),
+                worktree.as_ref().map(std::path::PathBuf::from),
+            ));
+        }
+
+        // The workspace root is the checkout the unbound panes are in, so a
+        // batch that puts every agent in its own worktree still roots the
+        // workspace at the repository rather than at whichever worktree came
+        // first.
+        let ws_cwd = groups
             .iter()
-            .find_map(|p| p.cwd.clone())
+            .find(|(worktree, _)| worktree.is_none())
+            .and_then(|(_, pane_idxs)| pane_idxs.iter().find_map(|i| planned[*i].cwd.clone()))
+            .or_else(|| planned.iter().find_map(|p| p.cwd.clone()))
             .unwrap_or_else(crate::launch_cwd::implicit_launch_cwd);
-        let mut ws = Workspace::with_layout_and_id(ws_id, &name, ws_cwd, tree);
+        let mut ws = Workspace::restored_with_id(ws_id, &name, ws_cwd, tabs, active_tab);
         ws.managed_worktrees = managed_worktrees;
         self.watch_git_dir(&ws);
         Self::spawn_initial_git_stats(ws_id, ws.cwd.clone(), cx);
@@ -3220,6 +3310,16 @@ impl PaneFlowApp {
                 {
                     return JsonRpcError::invalid_params("Surface not found").into_value();
                 }
+                // Discussion #41: a split into a tab bound to a worktree starts
+                // in that worktree. An explicit `cwd` still wins - a conductor
+                // that names a directory means it - but it is confined the same
+                // way, so a bound tab cannot be split into a sibling checkout
+                // by omission.
+                let spawn_cwd = tab.confine_cwd(
+                    spawn_cwd
+                        .clone()
+                        .or_else(|| (!ws.cwd.is_empty()).then(|| PathBuf::from(&ws.cwd))),
+                );
                 let new_terminal = cx.new(|cx| {
                     TerminalView::with_cwd_env_and_profile(
                         ws_id,
@@ -4300,6 +4400,52 @@ mod tests {
     use super::*;
     use std::sync::atomic::AtomicBool;
     use std::sync::{Arc, mpsc};
+
+    #[test]
+    fn a_batch_without_worktrees_is_the_single_tab_it_has_always_been() {
+        // The regression guard for the split below: `up` must not grow a second
+        // tab for a plain batch, and the pane order inside it is the order the
+        // conductor declared - `surface_ids` in the response are keyed on it.
+        let groups = group_up_panes_by_worktree(&[None, None, None]);
+        assert_eq!(groups, vec![(None, vec![0, 1, 2])]);
+        assert_eq!(group_up_panes_by_worktree(&[]), vec![]);
+    }
+
+    #[test]
+    fn each_worktree_gets_its_own_tab_in_declaration_order() {
+        let wt = |p: &str| Some(p.to_string());
+        // Two agents on one worktree share its tab; the shell that stayed in
+        // the main checkout keeps the workspace's own tab, which leads.
+        let groups = group_up_panes_by_worktree(&[
+            wt("/r.worktrees/b"),
+            None,
+            wt("/r.worktrees/a"),
+            wt("/r.worktrees/b"),
+        ]);
+        assert_eq!(
+            groups,
+            vec![
+                (None, vec![1]),
+                (wt("/r.worktrees/b"), vec![0, 3]),
+                (wt("/r.worktrees/a"), vec![2]),
+            ],
+            "tab order follows first appearance, not path order"
+        );
+    }
+
+    #[test]
+    fn an_all_worktree_batch_opens_no_empty_main_tab() {
+        let wt = |p: &str| Some(p.to_string());
+        let groups = group_up_panes_by_worktree(&[wt("/r.worktrees/a"), wt("/r.worktrees/b")]);
+        assert_eq!(
+            groups,
+            vec![
+                (wt("/r.worktrees/a"), vec![0]),
+                (wt("/r.worktrees/b"), vec![1])
+            ],
+            "no pane in the main checkout means no tab for it"
+        );
+    }
 
     fn test_ipc_request(method: &str, cancelled: bool) -> crate::ipc::IpcRequest {
         let (response_tx, _response_rx) = mpsc::channel();

--- a/src-app/src/app/mod.rs
+++ b/src-app/src/app/mod.rs
@@ -26,6 +26,7 @@ pub mod launch_pad;
 pub mod notifications;
 pub mod pane_palette;
 pub mod profile_menu;
+pub mod pull_request;
 pub mod self_update_flow;
 pub mod session;
 pub mod sessions_sidebar;

--- a/src-app/src/app/mod.rs
+++ b/src-app/src/app/mod.rs
@@ -33,6 +33,7 @@ pub mod settings;
 pub mod sidebar;
 pub mod sidebar_actions_menu;
 pub mod system_info_dialog;
+pub mod tab_worktree;
 pub mod telemetry_events;
 pub mod theme_picker;
 pub mod workspace_ops;

--- a/src-app/src/app/pane_palette.rs
+++ b/src-app/src/app/pane_palette.rs
@@ -19,8 +19,8 @@
 
 use gpui::{
     AnyElement, ClickEvent, Context, CursorStyle, Entity, FocusHandle, Focusable,
-    InteractiveElement, IntoElement, KeyDownEvent, MouseButton, ParentElement, ScrollHandle,
-    SharedString, Styled, WeakEntity, Window, div, prelude::*, px, svg,
+    InteractiveElement, IntoElement, KeyDownEvent, MouseButton, MouseUpEvent, ParentElement,
+    ScrollHandle, SharedString, Styled, WeakEntity, Window, deferred, div, prelude::*, px, svg,
 };
 use paneflow_config::schema::{ButtonCommand, PaneFlowConfig, TerminalSurfaceProfile};
 
@@ -28,11 +28,16 @@ use crate::PaneFlowApp;
 use crate::agent_launcher::TerminalAgent;
 use crate::layout::SplitDirection;
 use crate::pane::Pane;
-use crate::settings::components::select_item;
+use crate::settings::components::{select_item, select_menu, with_alpha};
 use crate::ui_primitives::squircle::squircle_fill;
+use crate::ui_primitives::{ROW_RADIUS, squircle_skin};
 
 /// Title of the surface the picker stands in for, until a preset renames it.
 pub(crate) const PALETTE_TAB_TITLE: &str = "New pane";
+
+/// Width of the picker's column: the preset buttons, the checkout select above
+/// them, and that select's menu all share one edge.
+const PICKER_WIDTH: f32 = 260.0;
 
 /// Where the picked preset lands - and therefore where the card is drawn.
 pub(crate) enum PalettePlacement {
@@ -46,6 +51,25 @@ pub(crate) enum PalettePlacement {
         target: WeakEntity<Pane>,
         direction: SplitDirection,
     },
+}
+
+/// What one row of the branch select points at.
+#[derive(Clone)]
+enum BranchTarget {
+    /// A branch, checked out on demand if nothing holds it yet.
+    Branch(String),
+    /// A checkout with no branch to name it - bound directly, since there is
+    /// no branch to resolve.
+    Checkout(std::path::PathBuf),
+}
+
+/// One row of the branch select.
+struct BranchOption {
+    target: BranchTarget,
+    label: String,
+    selected: bool,
+    /// Whether picking it has to create a worktree first.
+    needs_checkout: bool,
 }
 
 /// The three catalogues the picker projects (US-015). No fourth source, and
@@ -133,6 +157,9 @@ pub(crate) struct PanePaletteState {
     /// a split placement, which hands focus back to its target pane instead.
     pub(crate) restore_focus: Option<FocusHandle>,
     pub(crate) scroll: ScrollHandle,
+    /// Whether the branch menu is up over the presets. Closed on open, so the
+    /// picker always comes up on its presets.
+    pub(crate) branch_picker_open: bool,
 }
 
 impl PaneFlowApp {
@@ -205,6 +232,12 @@ impl PaneFlowApp {
             ws.sidebar_expanded = true;
         }
 
+        // The tab exists before any preset is picked, which is what lets the
+        // worktree be chosen BEFORE the agent's process spawns - the ordering
+        // Cursor and the Codex app both rely on. Refresh the repository's
+        // worktree list now so the header row is populated by the time the eye
+        // reaches it.
+        self.spawn_worktree_listing(ws_idx, cx);
         self.pane_palette = Some(PanePaletteState {
             ws_id,
             placement: PalettePlacement::Tab { tab_id },
@@ -212,6 +245,7 @@ impl PaneFlowApp {
             error: None,
             restore_focus,
             scroll: ScrollHandle::new(),
+            branch_picker_open: false,
         });
         let tab_idx = self.workspaces[ws_idx].active_tab_idx();
         self.focus_workspace_tab(ws_idx, tab_idx, window, cx);
@@ -246,6 +280,9 @@ impl PaneFlowApp {
             error: None,
             restore_focus: None,
             scroll: ScrollHandle::new(),
+            // A split fills an existing tab, whose binding already governs
+            // where its panes start: no worktree row, nothing to unfold.
+            branch_picker_open: false,
         });
         self.pending_palette_focus = true;
         cx.notify();
@@ -348,6 +385,12 @@ impl PaneFlowApp {
             self.pane_palette_set_error("This project is no longer open", cx);
             return;
         };
+        // A pane started now would spawn in the checkout being left behind: the
+        // binding is what decides its cwd, and it is not settled yet.
+        if let Some(branch) = self.branch_checkout_pending.clone() {
+            self.pane_palette_set_error(format!("Checking out {branch}..."), cx);
+            return;
+        }
         let Some(preset) = self.pane_palette_presets(ws_idx).get(idx).cloned() else {
             return;
         };
@@ -406,7 +449,19 @@ impl PaneFlowApp {
             .pane_palette_ws_idx()
             .map_or(0, |ws_idx| self.pane_palette_presets(ws_idx).len());
         let selected = self.pane_palette.as_ref().map_or(0, |p| p.selected);
+        let picker_open = self
+            .pane_palette
+            .as_ref()
+            .is_some_and(|palette| palette.branch_picker_open);
         match event.keystroke.key.as_str() {
+            // The checkout menu is a layer over the list, so Escape folds it
+            // first and only discards the palette once nothing sits above it.
+            "escape" if picker_open => {
+                if let Some(palette) = self.pane_palette.as_mut() {
+                    palette.branch_picker_open = false;
+                }
+                cx.notify();
+            }
             "escape" => self.close_pane_palette(window, cx),
             "enter" => {
                 if selected < len {
@@ -456,7 +511,7 @@ impl PaneFlowApp {
             .flex()
             .flex_col()
             .gap(px(2.))
-            .w(px(260.))
+            .w(px(PICKER_WIDTH))
             .max_h(px(420.))
             .overflow_y_scroll()
             .track_scroll(&palette.scroll);
@@ -464,17 +519,16 @@ impl PaneFlowApp {
             buttons = buttons.child(self.render_pane_palette_button(idx, preset, palette, ui, cx));
         }
 
-        let mut column = div()
-            .flex()
-            .flex_col()
-            .items_center()
-            .child(title)
-            .child(buttons);
+        let mut column = div().flex().flex_col().items_center().child(title);
+        if let Some(row) = self.render_palette_branch_row(palette, ui, cx) {
+            column = column.child(row);
+        }
+        column = column.child(buttons);
         if let Some(error) = &palette.error {
             column = column.child(
                 div()
                     .pt(px(10.))
-                    .max_w(px(260.))
+                    .max_w(px(PICKER_WIDTH))
                     .text_size(px(11.))
                     .text_color(ui.vc_deleted)
                     .child(error.clone()),
@@ -506,6 +560,263 @@ impl PaneFlowApp {
                     .justify_center()
                     .child(column),
             )
+            .into_any_element()
+    }
+
+    /// The palette's tab, as `(ws_idx, tab_idx)`. `None` for a split placement,
+    /// which fills an existing pane rather than a tab of its own.
+    fn pane_palette_tab(&self, palette: &PanePaletteState) -> Option<(usize, usize)> {
+        let PalettePlacement::Tab { tab_id } = &palette.placement else {
+            return None;
+        };
+        let ws_idx = self.pane_palette_ws_idx()?;
+        let tab_idx = self.workspaces[ws_idx]
+            .tabs()
+            .iter()
+            .position(|tab| tab.id == *tab_id)?;
+        Some((ws_idx, tab_idx))
+    }
+
+    /// The tab's branch, as a compact select above the presets.
+    ///
+    /// Branches, not worktrees: a worktree is only how git gives a second
+    /// branch a directory of its own, and what the user is choosing between is
+    /// the branch. Picking one that has no checkout yet makes it - see
+    /// [`PaneFlowApp::bind_tab_to_branch`] - so the choice reads the way it
+    /// does on a forge, where switching branch is one click and where the
+    /// directory lives is not the user's problem.
+    ///
+    /// A control, not a second list: the options live in a floating menu
+    /// anchored under the trigger, so opening it never pushes the presets down
+    /// and its rows never read as another column of launch buttons. Folding
+    /// them into the flow did exactly that - `select_item` cards stacked under
+    /// a bare text header looked like the agent buttons they sat above, and
+    /// the card was suddenly two lists deep.
+    ///
+    /// Here rather than in the tab's context menu because of the ordering every
+    /// product that does this respects: the branch is chosen BEFORE the
+    /// agent's process starts. T3 Code prepares the worktree and writes it on
+    /// the thread before dispatching the first turn
+    /// (`apps/server/src/ws.ts`), and rebinding a live session there costs a
+    /// kill and a restart of the provider process
+    /// (`ProviderCommandReactor.ts`, `cwdChanged`). A PTY cannot be resumed
+    /// that way, so Paneflow makes the choice while the tab is still empty and
+    /// leaves running panes alone afterwards.
+    ///
+    /// Only for a tab placement: a split lands in an existing tab, whose own
+    /// binding already governs where its panes start.
+    fn render_palette_branch_row(
+        &self,
+        palette: &PanePaletteState,
+        ui: crate::theme::UiColors,
+        cx: &mut Context<Self>,
+    ) -> Option<AnyElement> {
+        let (ws_idx, tab_idx) = self.pane_palette_tab(palette)?;
+        let ws = self.workspaces.get(ws_idx)?;
+        // Outside a repository there is nothing to switch between.
+        let root = ws.repo_root.clone()?;
+        let bound = ws.tabs().get(tab_idx)?.worktree.clone();
+        let listing = self.workspace_worktree_listing(ws_idx);
+        // The branch the tab works on today: the one its worktree holds, or
+        // the repository's own when it is unbound.
+        let on_branch = match bound.as_ref() {
+            Some(path) => listing
+                .iter()
+                .find(|entry| entry.path == *path)
+                .and_then(|entry| entry.branch.clone()),
+            None => Some(self.workspace_checkout_label(ws_idx)),
+        };
+
+        let mut options: Vec<BranchOption> = self
+            .workspace_branches(ws_idx)
+            .iter()
+            .map(|branch| BranchOption {
+                target: BranchTarget::Branch(branch.clone()),
+                label: branch.clone(),
+                selected: on_branch.as_deref() == Some(branch.as_str()),
+                // A branch git already has a directory for costs nothing to
+                // switch to; the others are checked out on the spot.
+                needs_checkout: !listing
+                    .iter()
+                    .any(|entry| entry.branch.as_deref() == Some(branch.as_str())),
+            })
+            .collect();
+        // Detached checkouts have no branch to be listed under, and dropping
+        // them would strand a tab bound to one - the Codex app creates every
+        // worktree of its own that way.
+        options.extend(
+            listing
+                .iter()
+                .filter(|entry| entry.branch.is_none() && entry.path != root)
+                .map(|entry| BranchOption {
+                    label: crate::workspace::worktree::checkout_label(None, &entry.path, &root),
+                    target: BranchTarget::Checkout(entry.path.clone()),
+                    selected: bound.as_deref() == Some(entry.path.as_path()),
+                    needs_checkout: false,
+                }),
+        );
+
+        // What the trigger names: the branch being checked out while git works,
+        // then whatever the tab settled on.
+        let current = self.branch_checkout_pending.clone().or_else(|| {
+            options
+                .iter()
+                .find(|option| option.selected)
+                .map(|option| option.label.clone())
+        });
+        let current = current
+            .or(on_branch)
+            .unwrap_or_else(|| self.workspace_checkout_label(ws_idx));
+        let open = palette.branch_picker_open;
+        let fill = with_alpha(ui.text, 0.05);
+
+        let trigger = squircle_skin(
+            div()
+                .id("palette-branch")
+                .flex_none()
+                .h(px(28.))
+                .px(px(8.))
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap(px(6.))
+                .w(px(PICKER_WIDTH)),
+            "palette-branch-group",
+            ROW_RADIUS,
+            open.then_some(fill),
+            Some(fill),
+        )
+        .cursor(CursorStyle::PointingHand)
+        .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+        // Toggle the render-time snapshot, not the live flag: the menu's
+        // `on_mouse_up_out` fires on this same release and has already cleared
+        // it, so a live toggle would reopen what the press was closing.
+        .on_click(cx.listener(move |this, _: &ClickEvent, _w, cx| {
+            if let Some(palette) = this.pane_palette.as_mut() {
+                palette.branch_picker_open = !open;
+                cx.notify();
+            }
+        }))
+        .child(
+            svg()
+                .size(px(11.))
+                .flex_none()
+                .path("icons/git-branch-sidebar.svg")
+                .text_color(ui.muted),
+        )
+        .child(
+            div()
+                .flex_1()
+                .min_w_0()
+                .overflow_x_hidden()
+                .whitespace_nowrap()
+                .text_ellipsis()
+                .text_size(px(11.))
+                .text_color(ui.text)
+                .child(current),
+        )
+        .child(
+            svg()
+                .size(px(11.))
+                .flex_none()
+                .path("icons/chevron-down.svg")
+                .text_color(ui.muted),
+        )
+        .when(open, |trigger| {
+            let mut menu = select_menu("palette-branch-menu", ui)
+                .absolute()
+                .top(px(32.))
+                .left(px(0.))
+                .w(px(PICKER_WIDTH))
+                .occlude()
+                // Dismiss on release for the reason the sidebar's popover does:
+                // the capture-phase `on_mouse_down_out` would close the menu
+                // before a row's own click could bubble.
+                .on_mouse_up_out(
+                    MouseButton::Left,
+                    cx.listener(|this, _: &MouseUpEvent, _w, cx| {
+                        if let Some(palette) = this.pane_palette.as_mut() {
+                            palette.branch_picker_open = false;
+                            cx.notify();
+                        }
+                    }),
+                );
+            for option in options {
+                menu =
+                    menu.child(self.render_palette_branch_option(option, ws_idx, tab_idx, ui, cx));
+            }
+            trigger.child(deferred(menu).with_priority(3))
+        });
+
+        Some(
+            div()
+                .flex_none()
+                .pb(px(10.))
+                .child(trigger)
+                .into_any_element(),
+        )
+    }
+
+    /// One branch in the select's menu: its name, a check when the tab is on
+    /// it, and otherwise a hint when picking it will have to make a checkout.
+    fn render_palette_branch_option(
+        &self,
+        option: BranchOption,
+        ws_idx: usize,
+        tab_idx: usize,
+        ui: crate::theme::UiColors,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let BranchOption {
+            target,
+            label,
+            selected,
+            needs_checkout,
+        } = option;
+        let id = SharedString::from(format!("palette-branch-{label}"));
+        select_item(id, selected, ui)
+            .on_click(cx.listener(move |this, _: &ClickEvent, _w, cx| {
+                match target.clone() {
+                    BranchTarget::Branch(branch) => {
+                        this.bind_tab_to_branch(ws_idx, tab_idx, branch, cx)
+                    }
+                    BranchTarget::Checkout(path) => {
+                        this.set_tab_worktree(ws_idx, tab_idx, Some(path), cx)
+                    }
+                }
+                if let Some(palette) = this.pane_palette.as_mut() {
+                    palette.branch_picker_open = false;
+                }
+                cx.notify();
+            }))
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .overflow_x_hidden()
+                    .whitespace_nowrap()
+                    .text_ellipsis()
+                    .text_color(ui.text)
+                    .child(label),
+            )
+            // One trailing slot, reserved either way so the names stay on one
+            // left edge: the check for where the tab is, and for a branch with
+            // no directory yet the icon for the one this will make.
+            .child(div().w(px(13.)).flex_none().child(if selected {
+                svg()
+                    .size(px(13.))
+                    .path("icons/check.svg")
+                    .text_color(ui.text)
+                    .into_any_element()
+            } else if needs_checkout {
+                svg()
+                    .size(px(13.))
+                    .path("icons/folder-plus.svg")
+                    .text_color(with_alpha(ui.muted, 0.7))
+                    .into_any_element()
+            } else {
+                div().size(px(13.)).into_any_element()
+            }))
             .into_any_element()
     }
 

--- a/src-app/src/app/pull_request.rs
+++ b/src-app/src/app/pull_request.rs
@@ -1,0 +1,322 @@
+//! Whether a branch shown in the rail already has a pull request.
+//!
+//! The rail's other optional lines read files: `HEAD` for the branch, a
+//! `git diff` for the counts. This one is a network answer, so it is cached
+//! per `(repository, branch)`, refreshed on the same 30 s tick that refreshes
+//! the git state, and only ever fetched while the `PR` switch is on.
+//!
+//! `gh` rather than `api.github.com` directly: it already holds the user's
+//! credentials, follows GitHub Enterprise hosts, and resolves which repository
+//! a directory belongs to. The cost is that this is GitHub-only - a GitLab or
+//! Gitea checkout simply never gets an icon, which is also what happens when
+//! `gh` is missing or logged out.
+
+use std::collections::{HashMap, HashSet};
+use std::time::{Duration, Instant};
+
+use gpui::{Context, Hsla, Rgba};
+
+use crate::PaneFlowApp;
+
+/// How long a lookup stays good. Long enough that opening and closing tabs
+/// does not re-query, short enough that a PR opened from the terminal shows up
+/// while you are still in the same sitting.
+const TTL: Duration = Duration::from_secs(300);
+/// Wall-clock bound for one `gh` call, well under the 30 s tick.
+const DEADLINE: Duration = Duration::from_secs(15);
+const STDOUT_CAP: u64 = 256 * 1024;
+
+/// A branch's pull request, in GitHub's own vocabulary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PrState {
+    Draft,
+    Open,
+    Merged,
+    Closed,
+}
+
+impl PrState {
+    /// GitHub's status colors, in Primer's light and dark values.
+    ///
+    /// Borrowed rather than mapped onto Paneflow's own palette: these four
+    /// colors are what a pull request means to anyone who has used GitHub, and
+    /// a green "merged" or a purple "open" would read as a different state
+    /// rather than as a house style.
+    pub(crate) fn color(self, ui: crate::theme::UiColors) -> Hsla {
+        let light = ui.surface.l > 0.5;
+        let hex = match (self, light) {
+            (PrState::Open, true) => 0x1a7f37,
+            (PrState::Open, false) => 0x3fb950,
+            (PrState::Draft, true) => 0x59636e,
+            (PrState::Draft, false) => 0x9198a1,
+            (PrState::Merged, true) => 0x8250df,
+            (PrState::Merged, false) => 0xab7df8,
+            (PrState::Closed, true) => 0xcf222e,
+            (PrState::Closed, false) => 0xf85149,
+        };
+        Hsla::from(Rgba {
+            r: ((hex >> 16) & 0xFF) as f32 / 255.0,
+            g: ((hex >> 8) & 0xFF) as f32 / 255.0,
+            b: (hex & 0xFF) as f32 / 255.0,
+            a: 1.0,
+        })
+    }
+}
+
+/// The pull request a branch is carried by, as the rail needs it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PullRequest {
+    pub number: u64,
+    pub state: PrState,
+}
+
+struct Cached {
+    /// `None` means "asked, and this branch has no pull request" - a real
+    /// answer worth caching, not a missing one.
+    value: Option<PullRequest>,
+    at: Instant,
+}
+
+/// Pull requests by `(repository root, branch)`.
+#[derive(Default)]
+pub(crate) struct PrStates {
+    entries: HashMap<(String, String), Cached>,
+    /// Lookups in flight, so a 30 s tick landing on a slow `gh` does not stack
+    /// a second call on the same branch.
+    inflight: HashSet<(String, String)>,
+    /// Repositories `gh` cannot answer for: not installed, logged out, or not
+    /// a GitHub remote. Asked once, never again this session - the answer does
+    /// not change under us, and retrying every tick would spend a subprocess
+    /// per repository forever.
+    unavailable: HashSet<String>,
+}
+
+impl PrStates {
+    fn key(repo_root: &str, branch: &str) -> (String, String) {
+        (repo_root.to_string(), branch.to_string())
+    }
+
+    pub(crate) fn get(&self, repo_root: &str, branch: &str) -> Option<PullRequest> {
+        self.entries
+            .get(&Self::key(repo_root, branch))
+            .and_then(|cached| cached.value)
+    }
+
+    /// Whether this branch is worth asking about right now: not already in
+    /// flight, not answered recently, and in a repository `gh` can speak for.
+    fn is_stale(&self, repo_root: &str, branch: &str) -> bool {
+        if self.unavailable.contains(repo_root) {
+            return false;
+        }
+        let key = Self::key(repo_root, branch);
+        if self.inflight.contains(&key) {
+            return false;
+        }
+        self.entries
+            .get(&key)
+            .is_none_or(|cached| cached.at.elapsed() > TTL)
+    }
+
+    fn store(&mut self, repo_root: &str, branch: &str, value: Option<PullRequest>) -> bool {
+        let key = Self::key(repo_root, branch);
+        self.inflight.remove(&key);
+        let changed = self.entries.get(&key).map(|c| c.value) != Some(value);
+        self.entries.insert(
+            key,
+            Cached {
+                value,
+                at: Instant::now(),
+            },
+        );
+        changed
+    }
+
+    fn mark_unavailable(&mut self, repo_root: &str, branch: &str) {
+        self.inflight.remove(&Self::key(repo_root, branch));
+        self.unavailable.insert(repo_root.to_string());
+    }
+}
+
+/// Read the pull request of one branch. Blocking: the caller runs it through
+/// `smol::unblock`.
+///
+/// `Err` means `gh` could not answer at all - the repository is then dropped
+/// for the session. `Ok(None)` is a real answer: no pull request here.
+fn lookup(repo_root: &std::path::Path, branch: &str) -> Result<Option<PullRequest>, ()> {
+    let mut cmd = std::process::Command::new("gh");
+    cmd.arg("-C")
+        .arg(repo_root)
+        .args([
+            "pr",
+            "list",
+            "--head",
+            branch,
+            "--state",
+            "all",
+            "--json",
+            "number,state,isDraft",
+            // A branch can carry a history of closed attempts under one open
+            // pull request; take enough of them to pick the one that counts.
+            "--limit",
+            "10",
+        ])
+        // `gh` prints a survey/update notice on a tty and reads config from
+        // the environment; neither matters here, but a pager would hang.
+        .env("GH_PAGER", "")
+        .env("NO_COLOR", "1");
+    let out = paneflow_process::run_with_timeout(cmd, DEADLINE, STDOUT_CAP).map_err(|_| ())?;
+    if !out.status.success() {
+        return Err(());
+    }
+    let parsed: serde_json::Value = serde_json::from_slice(&out.stdout).map_err(|_| ())?;
+    Ok(pick(parsed.as_array().map_or(&[], Vec::as_slice)))
+}
+
+/// The pull request that describes the branch, out of everything `gh` returned.
+///
+/// Open beats merged beats closed: a branch whose old attempt was closed and
+/// whose current one is open is, to the person looking at the rail, open. Ties
+/// go to the highest number, which is the most recent.
+fn pick(rows: &[serde_json::Value]) -> Option<PullRequest> {
+    rows.iter()
+        .filter_map(|row| {
+            let number = row.get("number")?.as_u64()?;
+            let draft = row.get("isDraft").and_then(serde_json::Value::as_bool) == Some(true);
+            let state = match row.get("state")?.as_str()? {
+                "OPEN" if draft => PrState::Draft,
+                "OPEN" => PrState::Open,
+                "MERGED" => PrState::Merged,
+                "CLOSED" => PrState::Closed,
+                _ => return None,
+            };
+            Some(PullRequest { number, state })
+        })
+        .max_by_key(|pr| {
+            let rank = match pr.state {
+                PrState::Open => 3,
+                PrState::Draft => 2,
+                PrState::Merged => 1,
+                PrState::Closed => 0,
+            };
+            (rank, pr.number)
+        })
+}
+
+impl PaneFlowApp {
+    /// The pull request of a branch, if one has been read.
+    pub(crate) fn pull_request_for(
+        &self,
+        repo_root: &std::path::Path,
+        branch: &str,
+    ) -> Option<PullRequest> {
+        self.pr_states.get(&repo_root.to_string_lossy(), branch)
+    }
+
+    /// Every `(repository, branch)` the rail is currently showing: each
+    /// workspace's own branch, plus the branch of every bound tab.
+    fn pr_probe_targets(&self) -> Vec<(std::path::PathBuf, String)> {
+        let mut seen = HashSet::new();
+        let mut out = Vec::new();
+        for ws in &self.workspaces {
+            let Some(repo_root) = ws.repo_root.clone() else {
+                continue;
+            };
+            let mut push = |branch: &str, out: &mut Vec<_>| {
+                if branch.is_empty() {
+                    return;
+                }
+                if seen.insert((repo_root.clone(), branch.to_string())) {
+                    out.push((repo_root.clone(), branch.to_string()));
+                }
+            };
+            if ws.is_git_repo {
+                push(&ws.git_branch, &mut out);
+            }
+            for tab in ws.tabs() {
+                if let Some(git) = self.tab_checkout_git(tab) {
+                    push(&git.branch.clone(), &mut out);
+                }
+            }
+        }
+        out
+    }
+
+    /// Refresh the pull requests of every branch the rail shows, off the render
+    /// thread. A no-op while the switch is off: nothing is drawn from it, so
+    /// nothing justifies the calls.
+    pub(crate) fn refresh_pull_requests(&mut self, cx: &mut Context<Self>) {
+        if !self.cached_config.sidebar_show.pr_enabled() {
+            return;
+        }
+        let stale: Vec<(std::path::PathBuf, String)> = self
+            .pr_probe_targets()
+            .into_iter()
+            .filter(|(repo_root, branch)| {
+                self.pr_states
+                    .is_stale(&repo_root.to_string_lossy(), branch)
+            })
+            .collect();
+        for (repo_root, branch) in stale {
+            self.pr_states
+                .inflight
+                .insert(PrStates::key(&repo_root.to_string_lossy(), &branch));
+            cx.spawn(
+                async move |this: gpui::WeakEntity<Self>, cx: &mut gpui::AsyncApp| {
+                    let read = smol::unblock({
+                        let repo_root = repo_root.clone();
+                        let branch = branch.clone();
+                        move || lookup(&repo_root, &branch)
+                    })
+                    .await;
+                    let _ = cx.update(|cx| {
+                        this.update(cx, |app: &mut Self, cx: &mut Context<Self>| {
+                            let key = repo_root.to_string_lossy();
+                            match read {
+                                Ok(value) => {
+                                    if app.pr_states.store(&key, &branch, value) {
+                                        cx.notify();
+                                    }
+                                }
+                                Err(()) => app.pr_states.mark_unavailable(&key, &branch),
+                            }
+                        })
+                    });
+                },
+            )
+            .detach();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PrState, pick};
+
+    fn row(number: u64, state: &str, draft: bool) -> serde_json::Value {
+        serde_json::json!({ "number": number, "state": state, "isDraft": draft })
+    }
+
+    #[test]
+    fn an_open_pull_request_outranks_a_closed_attempt() {
+        // The rail answers "is this branch in review?", so a branch whose
+        // first attempt was closed and whose second is open reads as open,
+        // whatever order `gh` listed them in.
+        let picked = pick(&[row(12, "OPEN", false), row(40, "CLOSED", false)]).unwrap();
+        assert_eq!(picked.number, 12);
+        assert_eq!(picked.state, PrState::Open);
+    }
+
+    #[test]
+    fn a_draft_is_its_own_state_and_the_newest_wins_a_tie() {
+        assert_eq!(pick(&[row(3, "OPEN", true)]).unwrap().state, PrState::Draft);
+        let picked = pick(&[row(7, "MERGED", false), row(9, "MERGED", false)]).unwrap();
+        assert_eq!(picked.number, 9, "the most recent of equals is the answer");
+    }
+
+    #[test]
+    fn no_rows_is_an_answer_and_junk_is_not_a_crash() {
+        assert!(pick(&[]).is_none());
+        assert!(pick(&[serde_json::json!({ "number": 1 })]).is_none());
+        assert!(pick(&[row(1, "SOMETHING_NEW", false)]).is_none());
+    }
+}

--- a/src-app/src/app/session.rs
+++ b/src-app/src/app/session.rs
@@ -114,6 +114,10 @@ impl PaneFlowApp {
                             teardown: wt.teardown.as_str().to_string(),
                         })
                         .collect(),
+                    // Folding a rail row survives a restart: reopening ten
+                    // folders you had deliberately closed is exactly the chore
+                    // the fold was avoiding.
+                    sidebar_collapsed: !ws.sidebar_expanded,
                 })
                 .collect(),
             // Persist the live UI mode so the restore branch reopens
@@ -420,6 +424,7 @@ impl PaneFlowApp {
                 Workspace::restored_with_id(ws_id, title.clone(), cwd, tabs, ws_session.active_tab);
 
             workspace.custom_buttons = ws_session.custom_buttons.clone();
+            workspace.sidebar_expanded = !ws_session.sidebar_collapsed;
             // EP-002 (orchestration-v2): rehydrate worktree ownership so the
             // close-time teardown still applies after a restart.
             workspace.managed_worktrees = ws_session

--- a/src-app/src/app/session.rs
+++ b/src-app/src/app/session.rs
@@ -413,6 +413,7 @@ impl PaneFlowApp {
                     tab_session.title.clone(),
                     restored_tab_title_source(tab_session, &ws_session.custom_buttons),
                     root,
+                    restored_tab_worktree(tab_session.worktree.as_deref()),
                 ));
             }
             let mut workspace =
@@ -845,6 +846,22 @@ fn rehydrate_managed_worktree(
         &def.branch,
         &def.teardown,
     )
+}
+
+/// Rehydrate a tab's worktree binding, dropping it when the checkout is gone.
+///
+/// A worktree can be removed between two runs - by `git worktree remove`, by
+/// another Paneflow session tearing down its own, or by hand. Restoring a
+/// binding to a directory that no longer exists would spawn every pane of that
+/// tab into a missing path; dropping it simply returns the tab to unbound,
+/// which is the state it can always fall back to.
+///
+/// Deliberately a plain `is_dir` and no canonicalization: this runs on the
+/// bootstrap path, and a stat is bounded where resolving symlinks across a dead
+/// network mount is not.
+fn restored_tab_worktree(path: Option<&str>) -> Option<PathBuf> {
+    let path = PathBuf::from(path.filter(|p| !p.is_empty())?);
+    path.is_dir().then_some(path)
 }
 
 fn persisted_expanded_paths(cwd: &str, expanded: &[PathBuf]) -> Vec<String> {

--- a/src-app/src/app/sidebar/context_menu.rs
+++ b/src-app/src/app/sidebar/context_menu.rs
@@ -424,12 +424,60 @@ impl PaneFlowApp {
             tab_idx,
             position,
         } = menu;
-        let can_reset_name = self
+        let tab = self
             .workspaces
             .get(ws_idx)
-            .and_then(|ws| ws.tabs().get(tab_idx))
-            .is_some_and(|tab| tab.title_is_user_owned());
-        let rows = if can_reset_name { 3. } else { 2. };
+            .and_then(|ws| ws.tabs().get(tab_idx));
+        let can_reset_name = tab.is_some_and(|tab| tab.title_is_user_owned());
+        let bound = tab.and_then(|tab| tab.worktree.clone());
+        // Discussion #41: the branches this tab can be moved to, one row each,
+        // exactly what the New pane picker offers - a branch with no worktree
+        // yet gets one when it is chosen. The repository's own branch is in
+        // there like any other, and picking it unbinds the tab.
+        let root = self
+            .workspaces
+            .get(ws_idx)
+            .and_then(|ws| ws.repo_root.clone())
+            .unwrap_or_default();
+        let listing = self.workspace_worktree_listing(ws_idx);
+        let on_branch = match bound.as_ref() {
+            Some(path) => listing
+                .iter()
+                .find(|entry| entry.path == *path)
+                .and_then(|entry| entry.branch.clone()),
+            None => Some(self.workspace_checkout_label(ws_idx)),
+        };
+        let mut branches: Vec<(Option<std::path::PathBuf>, String, bool)> = self
+            .workspace_branches(ws_idx)
+            .iter()
+            .map(|branch| {
+                let selected = on_branch.as_deref() == Some(branch.as_str());
+                (None, branch.clone(), selected)
+            })
+            .collect();
+        // A detached checkout is under no branch, and dropping it would strand
+        // a tab already bound to one.
+        branches.extend(
+            listing
+                .iter()
+                .filter(|entry| entry.branch.is_none() && entry.path != root)
+                .map(|entry| {
+                    let label =
+                        crate::workspace::worktree::checkout_label(None, &entry.path, &root);
+                    let selected = bound.as_deref() == Some(entry.path.as_path());
+                    (Some(entry.path.clone()), label, selected)
+                }),
+        );
+        // A single branch is where the tab already works: the section would
+        // only restate it.
+        let show_worktrees = branches.len() > 1;
+        let worktree_rows = if show_worktrees {
+            // The section header and its divider, plus one row per branch.
+            1. + branches.len() as f32
+        } else {
+            0.
+        };
+        let rows = if can_reset_name { 3. } else { 2. } + worktree_rows;
         let menu_height = px(8. + rows * 28.);
         let menu_pos = clamped_context_menu_position(position, px(248.), menu_height, window);
         let close_shortcut = self
@@ -482,6 +530,50 @@ impl PaneFlowApp {
                     cx.stop_propagation();
                 }),
             ))
+            .when(show_worktrees, |menu| {
+                let mut menu = menu.child(context_menu_divider(ui)).child(
+                    div()
+                        .px(px(8.))
+                        .pb(px(4.))
+                        .text_size(px(10.))
+                        .text_color(ui.muted)
+                        .child("Branch"),
+                );
+                for (detached, label, selected) in branches {
+                    let branch = label.clone();
+                    menu = menu.child(
+                        select_item(
+                            SharedString::from(format!("tab-branch-{label}")),
+                            selected,
+                            ui,
+                        )
+                        .cursor(CursorStyle::Arrow)
+                        .on_click(cx.listener(move |this, _: &ClickEvent, _window, cx| {
+                            this.tab_menu_open = None;
+                            match detached.clone() {
+                                Some(path) => {
+                                    this.set_tab_worktree(ws_idx, tab_idx, Some(path), cx)
+                                }
+                                None => {
+                                    this.bind_tab_to_branch(ws_idx, tab_idx, branch.clone(), cx)
+                                }
+                            }
+                            cx.stop_propagation();
+                        }))
+                        .child(
+                            div()
+                                .flex_1()
+                                .min_w_0()
+                                .overflow_x_hidden()
+                                .whitespace_nowrap()
+                                .text_ellipsis()
+                                .text_color(ui.text)
+                                .child(label),
+                        ),
+                    );
+                }
+                menu
+            })
             .into_any_element()
     }
 

--- a/src-app/src/app/sidebar/customize_menu.rs
+++ b/src-app/src/app/sidebar/customize_menu.rs
@@ -1,0 +1,399 @@
+//! The rail header's "Customize Sidebar" button and the popover it opens.
+//!
+//! Same shape as the diff dock's overflow menu
+//! ([`crate::app::diff_dock::options_menu`]), which is itself modeled on
+//! Cursor's changes-panel menu: a row carrying a side submenu, opened from a
+//! 28px header button skinned as a rail row.
+//!
+//! The submenu is a set of independent checks rather than a "compact /
+//! detailed" pair, because that is what the menu is: one switch per thing the
+//! row shows. Everything off is the rail as it ships, and it is what a fresh
+//! install gets.
+
+use gpui::{
+    AnyElement, AppContext, ClickEvent, Context, InteractiveElement, IntoElement, MouseButton,
+    MouseUpEvent, ParentElement, StatefulInteractiveElement, Styled, deferred, div,
+    prelude::FluentBuilder, px, svg,
+};
+
+use crate::PaneFlowApp;
+use crate::settings::components::{menu_surface, select_item};
+use crate::ui_primitives::{ROW_RADIUS, TooltipDelayExt, squircle_skin};
+
+use super::SidebarTooltip;
+use paneflow_config::schema::SidebarShow;
+
+/// What the popover needs to paint itself, read once by the caller while it
+/// still holds `&self`. A render helper cannot read the app entity back
+/// through `cx` - it is already mutably borrowed by the render pass.
+#[derive(Clone, Copy)]
+pub(super) struct CustomizeMenuState {
+    pub open: bool,
+    pub submenu_open: bool,
+    pub show: SidebarShow,
+    /// Whether every workspace with rows to show is unfolded, which is what
+    /// decides the Expand / Collapse row's wording. `None` when no workspace
+    /// has any: the row is then hidden rather than offering an action with
+    /// nothing to act on.
+    pub all_expanded: Option<bool>,
+}
+
+/// Width of the popover. Sized on its longest row, "Show" plus its chevron,
+/// with room for the labels a second section would add later.
+const MENU_WIDTH: f32 = 208.0;
+/// Width of the "Show" submenu. Holds "Diffstat" and its check without the
+/// flyout overhanging the rail.
+const SUBMENU_WIDTH: f32 = 156.0;
+
+impl PaneFlowApp {
+    /// Close the Customize Sidebar popover, folding its submenu with it so the
+    /// menu always reopens collapsed.
+    pub(crate) fn close_sidebar_customize_menu(&mut self, cx: &mut Context<Self>) {
+        if self.sidebar_customize_menu_open {
+            self.sidebar_customize_menu_open = false;
+            self.sidebar_show_submenu_open = false;
+            cx.notify();
+        }
+    }
+
+    /// Flip one of the rail's optional lines and persist the pair. The whole
+    /// `sidebar_show` object is written, because [`crate::config_writer`]
+    /// merges by top-level key and would otherwise drop the sibling.
+    fn toggle_sidebar_show(&mut self, line: SidebarShowLine, cx: &mut Context<Self>) {
+        // Hold the menu open across the flip. The popover's `on_mouse_up_out`
+        // runs in the capture phase of this very release - the submenu is
+        // outside the parent menu's bounds, so a click on a check reads as
+        // "outside" and closes it before this bubble handler runs. Turning two
+        // lines on has to be one trip through the menu, not two, and the rail
+        // behind the popover already shows each flip as it happens.
+        self.sidebar_customize_menu_open = true;
+        self.sidebar_show_submenu_open = true;
+
+        let mut show = self.cached_config.sidebar_show;
+        match line {
+            SidebarShowLine::Branch => show.branch = Some(!show.branch_enabled()),
+            SidebarShowLine::Diffstat => show.diffstat = Some(!show.diffstat_enabled()),
+            SidebarShowLine::Pr => show.pr = Some(!show.pr_enabled()),
+            SidebarShowLine::IndentGuide => {
+                show.indent_guide = Some(!show.indent_guide_enabled());
+            }
+        }
+        let value = serde_json::json!({
+            "branch": show.branch_enabled(),
+            "diffstat": show.diffstat_enabled(),
+            "pr": show.pr_enabled(),
+            "indent_guide": show.indent_guide_enabled(),
+        });
+        if !crate::config_writer::save_config_value_checked("sidebar_show", value) {
+            self.show_toast("Could not save the sidebar setting", cx);
+            return;
+        }
+        self.cached_config.sidebar_show = show;
+        // Read the pull requests now rather than at the next 30 s tick: a
+        // switch whose effect appears half a minute later reads as broken.
+        self.refresh_pull_requests(cx);
+        cx.notify();
+    }
+}
+
+/// The lines the "Show" submenu switches.
+#[derive(Clone, Copy)]
+enum SidebarShowLine {
+    Branch,
+    Diffstat,
+    Pr,
+    IndentGuide,
+}
+
+/// The header trigger, with the popover deferred over it while open. Skinned as
+/// a rail row like its `+` neighbor; while the menu is up the hover fill is
+/// pinned on as the resting fill so the trigger stays lit under the popover.
+pub(super) fn render_customize_sidebar_button(
+    state: CustomizeMenuState,
+    icon_size: f32,
+    ui: crate::theme::UiColors,
+    cx: &mut Context<PaneFlowApp>,
+) -> AnyElement {
+    let open = state.open;
+    let hover = crate::app::constants::sidebar_tab_hover_background();
+
+    squircle_skin(
+        div()
+            .id("sidebar-customize")
+            .flex_none()
+            .size(px(28.))
+            .flex()
+            .items_center()
+            .justify_center(),
+        "sidebar-customize-group",
+        ROW_RADIUS,
+        open.then_some(hover),
+        Some(hover),
+    )
+    .delayed_tooltip(|_w, cx| {
+        cx.new(|_| SidebarTooltip {
+            label: "Customize Sidebar".into(),
+        })
+        .into()
+    })
+    .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+    // Toggle off the render-time `open` snapshot, not the live state: while the
+    // menu is up, its `on_mouse_up_out` fires on this same release and has
+    // already cleared the flag, so a live toggle would re-open it and a second
+    // press on the trigger could never close the menu.
+    .on_click(cx.listener(move |this, _: &ClickEvent, _w, cx| {
+        this.sidebar_customize_menu_open = !open;
+        if open {
+            this.sidebar_show_submenu_open = false;
+        }
+        cx.notify();
+    }))
+    .child(
+        svg()
+            .size(px(icon_size))
+            .flex_none()
+            .path("icons/filter-2.svg")
+            .text_color(ui.muted),
+    )
+    .when(open, |trigger| trigger.child(render_menu(state, ui, cx)))
+    .into_any_element()
+}
+
+fn render_menu(
+    state: CustomizeMenuState,
+    ui: crate::theme::UiColors,
+    cx: &mut Context<PaneFlowApp>,
+) -> AnyElement {
+    // `menu_surface` rather than `select_menu`: the latter bakes in an
+    // `overflow_y_scroll` host, and the submenu has to fly out of this menu's
+    // own box.
+    let menu = menu_surface(div().id("sidebar-customize-menu"), ui)
+        .flex()
+        .flex_col()
+        .gap(px(1.))
+        .p(px(4.))
+        .w(px(MENU_WIDTH))
+        .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+        // Dismiss on release, not on press: `on_mouse_down_out` runs in the
+        // capture phase (no bubble `stop_propagation` holds it back) and the
+        // submenu flies out of this menu's bounds, so a press on a submenu row
+        // read as "outside", closed the menu, and the row's click died with the
+        // frame. Closing on mouse-up keeps that click alive, because the
+        // capture close and the bubble click share one event.
+        .on_mouse_up_out(
+            MouseButton::Left,
+            cx.listener(|this, _: &MouseUpEvent, _w, cx| {
+                this.close_sidebar_customize_menu(cx);
+            }),
+        )
+        .child(render_show_row(state, ui, cx))
+        .when_some(state.all_expanded, |menu, all_expanded| {
+            menu.child(
+                div()
+                    .mx(px(6.))
+                    .my(px(4.))
+                    .h(px(1.))
+                    .bg(crate::settings::components::menu_divider_color(ui)),
+            )
+            .child(render_expand_all_row(all_expanded, ui, cx))
+        });
+
+    deferred(
+        div()
+            .absolute()
+            .top(px(32.))
+            .left(px(0.))
+            .occlude()
+            .child(menu),
+    )
+    .with_priority(3)
+    .into_any_element()
+}
+
+impl PaneFlowApp {
+    /// Fold or unfold every workspace at once.
+    ///
+    /// One row rather than two: at any moment only one of the two is worth
+    /// doing, and the label names that one. Nothing is written to disk -
+    /// `sidebar_expanded` is session state, like the per-row chevron this
+    /// mirrors.
+    ///
+    /// The menu stays up, and the row re-labels itself under the pointer: the
+    /// rail behind the popover shows each fold as it happens, so folding and
+    /// unfolding again is one trip through the menu. Held open the way
+    /// [`Self::toggle_sidebar_show`] holds it, for the same capture-phase
+    /// reason.
+    fn set_all_workspaces_expanded(&mut self, expanded: bool, cx: &mut Context<Self>) {
+        self.sidebar_customize_menu_open = true;
+        for ws in &mut self.workspaces {
+            ws.sidebar_expanded = expanded;
+        }
+        self.save_session(cx);
+        cx.notify();
+    }
+}
+
+/// "Collapse all" while everything is open, "Expand all" otherwise: the label
+/// is the action, not the state. No leading icon - the rows above it use that
+/// column for what a switch is about, and this row is about the rail itself.
+fn render_expand_all_row(
+    all_expanded: bool,
+    ui: crate::theme::UiColors,
+    cx: &mut Context<PaneFlowApp>,
+) -> AnyElement {
+    select_item("sidebar-customize-expand-all", false, ui)
+        .on_click(cx.listener(move |this, _: &ClickEvent, _w, cx| {
+            this.set_all_workspaces_expanded(!all_expanded, cx);
+        }))
+        .child(menu_label(
+            if all_expanded {
+                "Collapse all"
+            } else {
+                "Expand all"
+            },
+            ui,
+        ))
+        .into_any_element()
+}
+
+/// "Show  >": the row that opens the side submenu. No value on the right - what
+/// is on is what the submenu's checks say, and a "Branch, Diffstat" summary
+/// here would restate the checks one row away from them.
+fn render_show_row(
+    state: CustomizeMenuState,
+    ui: crate::theme::UiColors,
+    cx: &mut Context<PaneFlowApp>,
+) -> AnyElement {
+    let submenu_open = state.submenu_open;
+    select_item("sidebar-customize-show", submenu_open, ui)
+        .relative()
+        .on_click(cx.listener(|this, _: &ClickEvent, _w, cx| {
+            this.sidebar_show_submenu_open = !this.sidebar_show_submenu_open;
+            cx.notify();
+        }))
+        .child(menu_label("Show", ui))
+        .child(
+            svg()
+                .size(px(13.))
+                .flex_none()
+                .path("icons/chevron-right.svg")
+                .text_color(ui.muted),
+        )
+        .when(submenu_open, |row| {
+            row.child(render_show_submenu(state.show, ui, cx))
+        })
+        .into_any_element()
+}
+
+/// The submenu flies out to the right: the rail is the window's left edge, so
+/// the dock's leftward flyout would land off screen here.
+fn render_show_submenu(
+    show: SidebarShow,
+    ui: crate::theme::UiColors,
+    cx: &mut Context<PaneFlowApp>,
+) -> AnyElement {
+    let menu = menu_surface(div().id("sidebar-show-submenu"), ui)
+        .flex()
+        .flex_col()
+        .gap(px(1.))
+        .p(px(4.))
+        .w(px(SUBMENU_WIDTH))
+        .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+        .child(render_show_option(
+            "Branch",
+            "icons/git-branch-sidebar.svg",
+            SidebarShowLine::Branch,
+            show.branch_enabled(),
+            ui,
+            cx,
+        ))
+        .child(render_show_option(
+            "Diffstat",
+            "icons/diff-unified.svg",
+            SidebarShowLine::Diffstat,
+            show.diffstat_enabled(),
+            ui,
+            cx,
+        ))
+        .child(render_show_option(
+            "PR",
+            "icons/git-pull-request.svg",
+            SidebarShowLine::Pr,
+            show.pr_enabled(),
+            ui,
+            cx,
+        ))
+        .child(render_show_option(
+            "Indent guide",
+            "icons/list.svg",
+            SidebarShowLine::IndentGuide,
+            show.indent_guide_enabled(),
+            ui,
+            cx,
+        ));
+
+    deferred(
+        div()
+            .absolute()
+            .top(px(-5.))
+            .left(px(MENU_WIDTH - 12.))
+            .occlude()
+            .child(menu),
+    )
+    .with_priority(4)
+    .into_any_element()
+}
+
+/// One switch. Clicking it flips the line and leaves the menu up - see
+/// [`PaneFlowApp::toggle_sidebar_show`] for why that takes an explicit hold.
+fn render_show_option(
+    label: &'static str,
+    icon: &'static str,
+    line: SidebarShowLine,
+    checked: bool,
+    ui: crate::theme::UiColors,
+    cx: &mut Context<PaneFlowApp>,
+) -> AnyElement {
+    let id = match line {
+        SidebarShowLine::Branch => "sidebar-show-branch",
+        SidebarShowLine::Diffstat => "sidebar-show-diffstat",
+        SidebarShowLine::Pr => "sidebar-show-pr",
+        SidebarShowLine::IndentGuide => "sidebar-show-indent-guide",
+    };
+
+    select_item(id, false, ui)
+        .on_click(cx.listener(move |this, _: &ClickEvent, _w, cx| {
+            this.toggle_sidebar_show(line, cx);
+        }))
+        .child(
+            svg()
+                .size(px(13.))
+                .flex_none()
+                .path(icon)
+                .text_color(ui.muted),
+        )
+        .child(menu_label(label, ui))
+        // The check's slot is reserved whether or not it is drawn, so
+        // unchecking a line never shifts the label beside it.
+        .child(div().w(px(14.)).flex_none().child(if checked {
+            svg()
+                .size(px(13.))
+                .path("icons/check.svg")
+                .text_color(ui.text)
+                .into_any_element()
+        } else {
+            div().size(px(13.)).into_any_element()
+        }))
+        .into_any_element()
+}
+
+fn menu_label(label: &'static str, ui: crate::theme::UiColors) -> AnyElement {
+    div()
+        .flex_1()
+        .min_w_0()
+        .whitespace_nowrap()
+        .text_size(px(13.))
+        .text_color(ui.text)
+        .child(label)
+        .into_any_element()
+}

--- a/src-app/src/app/sidebar/mod.rs
+++ b/src-app/src/app/sidebar/mod.rs
@@ -8,6 +8,7 @@
 //! remain in `main.rs` because they cross module boundaries.
 
 pub(crate) mod context_menu;
+pub(crate) mod customize_menu;
 
 use crate::ui_primitives::TooltipDelayExt;
 use gpui::{
@@ -219,6 +220,36 @@ fn sidebar_row_shell() -> gpui::Div {
         .gap(px(SIDEBAR_ROW_GAP))
 }
 
+/// The hairline that ties a workspace's tab rows to the folder above them.
+///
+/// Centered on the folder icon's slot rather than inset from the row's edge:
+/// what the line stands under is that glyph, which is also where the tab rows
+/// align their own leading slot. Painted before the row, so a selected row's
+/// fill covers it instead of the line cutting across the card.
+///
+/// One segment per row rather than one line for the group: the rail is a flat
+/// list of rows - that is what the drop dividers between them address - so
+/// there is no element spanning a workspace's tabs to hang a single line on.
+/// The rows are contiguous, so the segments read as one line.
+fn render_sidebar_indent_guide(ui: crate::theme::UiColors, interrupted: bool) -> Vec<gpui::Div> {
+    let color = ui.text.opacity(0.08);
+    let left = px(SIDEBAR_ROW_PADDING_X + (SIDEBAR_FOLDER_ICON_WIDTH / 2.).floor());
+    let segment = move || div().absolute().left(left).w(px(1.)).bg(color);
+    if !interrupted {
+        return vec![segment().top_0().bottom_0()];
+    }
+    // A row whose agent badge sits in that same column breaks the line rather
+    // than letting it run under the glyph: the spinner is a moving mark, and a
+    // hairline crossing it reads as part of it. The gap is the badge's own
+    // slot, so the line resumes exactly where the glyph ends.
+    let center = SIDEBAR_ROW_PADDING_Y + SIDEBAR_ROW_LINE_HEIGHT / 2.;
+    let radius = SIDEBAR_AGENT_ICON_SLOT_WIDTH / 2.;
+    vec![
+        segment().top_0().h(px(center - radius)),
+        segment().top(px(center + radius)).bottom_0(),
+    ]
+}
+
 /// A rail row: the shared continuous-corner skin, with `body` on top.
 fn squircle_row(
     shell: gpui::Stateful<gpui::Div>,
@@ -370,6 +401,19 @@ fn visible_service_ports(
         .copied()
         .filter(|port| service_labels.contains_key(port))
         .collect()
+}
+
+/// Whether a tab row prints its insertion and deletion counts.
+///
+/// Two ways to get nothing: the switch is off, or the checkout is clean. The
+/// counts answer "how much has changed here", and when the answer is none the
+/// question was never asked - a permanent "0" would spend a slot on the rows
+/// with the least to say.
+fn tab_diffstat_visible(
+    show: paneflow_config::schema::SidebarShow,
+    stats: &crate::workspace::GitDiffStats,
+) -> bool {
+    show.diffstat_enabled() && (stats.insertions > 0 || stats.deletions > 0)
 }
 
 fn sidebar_service_summary(
@@ -672,40 +716,61 @@ impl PaneFlowApp {
                         .text_color(ui.muted)
                         .child("Workspaces"),
                 )
-                .child({
-                    // The header action is skinned as a rail row, not as its
-                    // own control: same hover tint and same continuous corner,
-                    // so it reads as part of the list it heads.
-                    let hover_bg = crate::app::constants::sidebar_tab_hover_background();
-                    squircle_skin(
-                        div()
-                            .id("sidebar-new-workspace")
-                            .size(px(28.))
-                            .flex()
-                            .items_center()
-                            .justify_center(),
-                        "sidebar-new-workspace-group",
-                        ROW_RADIUS,
-                        None,
-                        Some(hover_bg),
-                    )
-                    .delayed_tooltip(move |_w, cx| {
-                        cx.new(|_| SidebarTooltip {
-                            label: new_workspace_tooltip.clone().into(),
-                        })
-                        .into()
-                    })
-                    .on_click(cx.listener(|this, _: &ClickEvent, window, cx| {
-                        this.create_workspace_with_picker(window, cx);
-                    }))
-                    .child(
-                        svg()
-                            .size(px(SIDEBAR_FOLDER_ICON_WIDTH))
-                            .flex_none()
-                            .path("icons/folder-plus.svg")
-                            .text_color(ui.muted),
-                    )
-                }),
+                .child(
+                    div()
+                        .flex_none()
+                        .flex()
+                        .flex_row()
+                        .items_center()
+                        // Tight enough that the pair reads as one trailing
+                        // cluster rather than as two unrelated controls.
+                        .gap(px(2.))
+                        .child(customize_menu::render_customize_sidebar_button(
+                            customize_menu::CustomizeMenuState {
+                                open: self.sidebar_customize_menu_open,
+                                submenu_open: self.sidebar_show_submenu_open,
+                                show: self.cached_config.sidebar_show,
+                                all_expanded: self.all_workspaces_expanded(),
+                            },
+                            SIDEBAR_FOLDER_ICON_WIDTH,
+                            ui,
+                            cx,
+                        ))
+                        .child({
+                            // The header action is skinned as a rail row, not as its
+                            // own control: same hover tint and same continuous corner,
+                            // so it reads as part of the list it heads.
+                            let hover_bg = crate::app::constants::sidebar_tab_hover_background();
+                            squircle_skin(
+                                div()
+                                    .id("sidebar-new-workspace")
+                                    .size(px(28.))
+                                    .flex()
+                                    .items_center()
+                                    .justify_center(),
+                                "sidebar-new-workspace-group",
+                                ROW_RADIUS,
+                                None,
+                                Some(hover_bg),
+                            )
+                            .delayed_tooltip(move |_w, cx| {
+                                cx.new(|_| SidebarTooltip {
+                                    label: new_workspace_tooltip.clone().into(),
+                                })
+                                .into()
+                            })
+                            .on_click(cx.listener(|this, _: &ClickEvent, window, cx| {
+                                this.create_workspace_with_picker(window, cx);
+                            }))
+                            .child(
+                                svg()
+                                    .size(px(SIDEBAR_FOLDER_ICON_WIDTH))
+                                    .flex_none()
+                                    .path("icons/folder-plus.svg")
+                                    .text_color(ui.muted),
+                            )
+                        }),
+                ),
         );
 
         // Workspace list - scrollable area. Wheel-scroll comes from
@@ -806,6 +871,24 @@ impl PaneFlowApp {
             }
         }
         rows
+    }
+
+    /// Whether every workspace that has rows to show is unfolded.
+    ///
+    /// `None` when none of them has any: an empty shell shows no child row
+    /// whether it is folded or not, so counting it would offer a "Collapse
+    /// all" that visibly does nothing.
+    fn all_workspaces_expanded(&self) -> Option<bool> {
+        let mut rows_somewhere = false;
+        let mut all = true;
+        for ws in &self.workspaces {
+            if ws.is_empty_shell() {
+                continue;
+            }
+            rows_somewhere = true;
+            all &= ws.sidebar_expanded;
+        }
+        rows_somewhere.then_some(all)
     }
 
     fn render_workspace_rows(
@@ -1433,7 +1516,27 @@ impl PaneFlowApp {
                 }
             }));
 
-        let row = squircle_row(row_shell, tab_group, resting_bg, hovered_bg, title_row);
+        // The rail's optional second line (branch, diffstat). Built as a column
+        // only when that line exists, so with both switches off the row is the
+        // single-line row it has always been - same height, same geometry,
+        // nothing reserved.
+        let body = match self.render_tab_checkout_meta(
+            ws,
+            tab,
+            SIDEBAR_FOLDER_ICON_WIDTH + SIDEBAR_TITLE_ROW_GAP,
+            ui,
+        ) {
+            Some(meta) => div()
+                .flex()
+                .flex_col()
+                .gap(px(SIDEBAR_ROW_GAP))
+                .child(title_row)
+                .child(meta)
+                .into_any_element(),
+            None => title_row.into_any_element(),
+        };
+
+        let row = squircle_row(row_shell, tab_group, resting_bg, hovered_bg, body);
 
         div()
             .id(SharedString::from(format!("tab-drop-{tab_id}")))
@@ -1441,7 +1544,14 @@ impl PaneFlowApp {
             .flex_none()
             .flex()
             .flex_col()
+            // The indent hairline is absolute against this box, so it spans a
+            // row whether that row grew a second line or not.
+            .relative()
             .rounded(ROW_RADIUS)
+            .when(
+                self.cached_config.sidebar_show.indent_guide_enabled(),
+                |el| el.children(render_sidebar_indent_guide(ui, row_agent_status.is_some())),
+            )
             .child(row)
     }
 
@@ -1451,9 +1561,10 @@ impl PaneFlowApp {
         ui: crate::theme::UiColors,
         cx: &mut Context<Self>,
     ) -> Option<AnyElement> {
-        // Detected services only. Neither the git branch nor a diffstat is
-        // rendered in the rail: both crowded the row for little signal, and the
-        // Diff view is where change counts belong.
+        // Detected services only. The branch and the diffstat belong to the tab
+        // rows below (discussion #41): a workspace is one folder, so its branch
+        // is a near-constant line, while a tab bound to a worktree is precisely
+        // the thing a branch tells apart from its siblings.
         let service = sidebar_service_summary(&ws.active_ports, &ws.service_labels)?;
         let mut meta_row = div()
             .flex()
@@ -1468,96 +1579,278 @@ impl PaneFlowApp {
             .text_xs()
             .text_color(ui.muted);
 
-        let port = service.primary;
-        let workspace_id = ws.id;
-        let info = ws.service_labels.get(&port);
-        let is_frontend = info.is_some_and(|service| service.is_frontend);
-        let service_name = info
-            .and_then(|service| service.label.clone())
-            .unwrap_or_else(|| "Local service".to_string());
-        let service_tooltip: SharedString = format!("{service_name}  :{port}").into();
+        {
+            let port = service.primary;
+            let workspace_id = ws.id;
+            let info = ws.service_labels.get(&port);
+            let is_frontend = info.is_some_and(|service| service.is_frontend);
+            let service_name = info
+                .and_then(|service| service.label.clone())
+                .unwrap_or_else(|| "Local service".to_string());
+            let service_tooltip: SharedString = format!("{service_name}  :{port}").into();
 
-        if is_frontend {
-            let url = info
-                .and_then(|service| service.url.clone())
-                .unwrap_or_else(|| format!("http://localhost:{port}"));
-            meta_row = meta_row.child(
-                div()
-                    .id(SharedString::from(format!("port-{workspace_id}-{port}")))
-                    .flex()
-                    .flex_row()
-                    .items_center()
-                    .gap(px(2.))
-                    .text_size(px(10.))
-                    .font_weight(FontWeight::MEDIUM)
-                    .text_color(ui.muted)
-                    .hover(move |style| style.text_color(ui.text))
-                    .delayed_tooltip({
-                        let label = service_tooltip.clone();
-                        move |_w, cx| {
-                            cx.new(|_| SidebarTooltip {
-                                label: label.clone(),
-                            })
-                            .into()
-                        }
-                    })
-                    .on_click(cx.listener(move |this, _: &ClickEvent, _window, cx| {
-                        this.open_workspace_service_url(&url, cx);
-                        cx.stop_propagation();
-                    }))
-                    .child(
-                        svg()
-                            .size(px(10.))
-                            .flex_none()
-                            .path("icons/world.svg")
-                            .text_color(ui.muted),
-                    )
-                    .child(format!(":{port}")),
-            );
-        } else {
-            meta_row = meta_row.child(
-                div()
-                    .id(SharedString::from(format!(
-                        "port-{workspace_id}-{port}-info"
-                    )))
-                    .text_size(px(10.))
-                    .text_color(ui.muted)
-                    .delayed_tooltip({
-                        let label = service_tooltip.clone();
-                        move |_w, cx| {
-                            cx.new(|_| SidebarTooltip {
-                                label: label.clone(),
-                            })
-                            .into()
-                        }
-                    })
-                    .child(format!(":{port}")),
-            );
-        }
-
-        if service.overflow > 0 {
-            let overflow = service.overflow;
-            meta_row = meta_row.child(
-                div()
-                    .id(SharedString::from(format!("ports-{workspace_id}-overflow")))
-                    .flex_none()
-                    .text_size(px(10.))
-                    .font_weight(FontWeight::MEDIUM)
-                    .text_color(ui.muted)
-                    .delayed_tooltip(move |_w, cx| {
-                        cx.new(|_| SidebarTooltip {
-                            label: format!(
-                                "{overflow} more services · Right-click workspace to view"
-                            )
-                            .into(),
+            if is_frontend {
+                let url = info
+                    .and_then(|service| service.url.clone())
+                    .unwrap_or_else(|| format!("http://localhost:{port}"));
+                meta_row = meta_row.child(
+                    div()
+                        .id(SharedString::from(format!("port-{workspace_id}-{port}")))
+                        .flex()
+                        .flex_row()
+                        .items_center()
+                        .gap(px(2.))
+                        .text_size(px(10.))
+                        .font_weight(FontWeight::MEDIUM)
+                        .text_color(ui.muted)
+                        .hover(move |style| style.text_color(ui.text))
+                        .delayed_tooltip({
+                            let label = service_tooltip.clone();
+                            move |_w, cx| {
+                                cx.new(|_| SidebarTooltip {
+                                    label: label.clone(),
+                                })
+                                .into()
+                            }
                         })
-                        .into()
-                    })
-                    .child(format!("+{overflow}")),
-            );
+                        .on_click(cx.listener(move |this, _: &ClickEvent, _window, cx| {
+                            this.open_workspace_service_url(&url, cx);
+                            cx.stop_propagation();
+                        }))
+                        .child(
+                            svg()
+                                .size(px(10.))
+                                .flex_none()
+                                .path("icons/world.svg")
+                                .text_color(ui.muted),
+                        )
+                        .child(format!(":{port}")),
+                );
+            } else {
+                meta_row = meta_row.child(
+                    div()
+                        .id(SharedString::from(format!(
+                            "port-{workspace_id}-{port}-info"
+                        )))
+                        .text_size(px(10.))
+                        .text_color(ui.muted)
+                        .delayed_tooltip({
+                            let label = service_tooltip.clone();
+                            move |_w, cx| {
+                                cx.new(|_| SidebarTooltip {
+                                    label: label.clone(),
+                                })
+                                .into()
+                            }
+                        })
+                        .child(format!(":{port}")),
+                );
+            }
+
+            if service.overflow > 0 {
+                let overflow = service.overflow;
+                meta_row = meta_row.child(
+                    div()
+                        .id(SharedString::from(format!("ports-{workspace_id}-overflow")))
+                        .flex_none()
+                        .text_size(px(10.))
+                        .font_weight(FontWeight::MEDIUM)
+                        .text_color(ui.muted)
+                        .delayed_tooltip(move |_w, cx| {
+                            cx.new(|_| SidebarTooltip {
+                                label: format!(
+                                    "{overflow} more services · Right-click workspace to view"
+                                )
+                                .into(),
+                            })
+                            .into()
+                        })
+                        .child(format!("+{overflow}")),
+                );
+            }
         }
 
         Some(meta_row.into_any_element())
+    }
+
+    /// The rail's optional git line: the branch on the left, the diffstat
+    /// pinned right, each behind its own `sidebar_show` switch. Both read what
+    /// the workspace already polls (`git_branch`, `git_stats`, refreshed off
+    /// the render thread by the bootstrap git watcher), so this starts no
+    /// subprocess of its own.
+    ///
+    /// `None` outside a repository, and `None` for a clean checkout with only
+    /// the diffstat on: the counts answer "how much has changed here", and when
+    /// the answer is nothing the question was never asked.
+    /// The checkout a session tab row reports on: its own worktree when the
+    /// tab is bound to one (discussion #41), otherwise its workspace's.
+    ///
+    /// The fallback is what makes the two switches useful before any tab is
+    /// bound: an unbound tab still works in a checkout, it just shares it with
+    /// its siblings. Binding is what makes the line differ between two tabs of
+    /// one workspace; the line itself does not wait for it.
+    ///
+    /// Reads state the off-thread git probes already cache
+    /// ([`crate::app::tab_worktree`]) or the workspace already holds; starts no
+    /// subprocess of its own.
+    /// The branch a tab row stands on, empty for a detached checkout. Keyed on
+    /// by the pull-request marker, which only means something for a branch.
+    fn tab_row_branch(&self, ws: &Workspace, tab: &Tab) -> String {
+        match tab.worktree.as_ref() {
+            Some(_) => self
+                .tab_checkout_git(tab)
+                .map(|git| git.branch.clone())
+                .unwrap_or_default(),
+            None => ws.git_branch.clone(),
+        }
+    }
+
+    fn tab_row_checkout(
+        &self,
+        ws: &Workspace,
+        tab: &Tab,
+    ) -> Option<(String, crate::workspace::GitDiffStats)> {
+        let label = |branch: &str, path: &std::path::Path| {
+            crate::workspace::worktree::checkout_label(Some(branch), path, &ws.worktree_root)
+        };
+        match tab.worktree.as_ref() {
+            Some(path) => {
+                let git = self.tab_checkout_git(tab)?;
+                git.is_repo
+                    .then(|| (label(&git.branch, path), git.stats.clone()))
+            }
+            None => ws.is_git_repo.then(|| {
+                (
+                    label(&ws.git_branch, &ws.worktree_root),
+                    ws.git_stats.clone(),
+                )
+            }),
+        }
+    }
+
+    /// The second line of a session tab row: the branch on the left, the
+    /// diffstat pinned right, each behind its own switch.
+    ///
+    /// `None` when both switches are off - the row is then the single-line row
+    /// it has always been, same height, nothing reserved - and when the tab
+    /// works outside a repository, where neither value exists.
+    fn render_tab_checkout_meta(
+        &self,
+        ws: &Workspace,
+        tab: &Tab,
+        indent: f32,
+        ui: crate::theme::UiColors,
+    ) -> Option<AnyElement> {
+        let show = self.cached_config.sidebar_show;
+        if !show.any_enabled() {
+            return None;
+        }
+        let (label, stats) = self.tab_row_checkout(ws, tab)?;
+        let draw_branch = show.branch_enabled() && !label.is_empty();
+        let draw_counts = tab_diffstat_visible(show, &stats);
+        if !draw_branch && !draw_counts {
+            return None;
+        }
+
+        // A branch already in review is marked by its own glyph rather than by
+        // an extra one: the icon is the row's only spare millimeter, and "this
+        // is a branch" is the least useful thing it can say once you know the
+        // line is a branch. Absent PR, absent marker - the switch turns on the
+        // lookup, not the icon.
+        let pr = show
+            .pr_enabled()
+            .then(|| self.tab_row_branch(ws, tab))
+            .and_then(|branch| {
+                let repo_root = ws.repo_root.as_ref()?;
+                (!branch.is_empty())
+                    .then(|| self.pull_request_for(repo_root, &branch))
+                    .flatten()
+            });
+
+        let branch = draw_branch.then(|| {
+            div()
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap(px(3.))
+                .flex_1()
+                .min_w_0()
+                .child(
+                    svg()
+                        .size(px(12.))
+                        .flex_none()
+                        .path(match pr {
+                            Some(_) => "icons/git-pull-request.svg",
+                            None => "icons/git-branch-sidebar.svg",
+                        })
+                        .text_color(match pr {
+                            Some(pr) => pr.state.color(ui),
+                            None => ui.muted,
+                        }),
+                )
+                .child(
+                    div()
+                        .flex_1()
+                        .min_w_0()
+                        .overflow_x_hidden()
+                        .whitespace_nowrap()
+                        .text_ellipsis()
+                        // Same size as the tab's name above it, not the 10 px
+                        // a meta line usually gets: the branch is what tells
+                        // two tabs of one project apart, so it reads as a
+                        // value and not as a caption.
+                        .text_sm()
+                        .text_color(ui.muted)
+                        .child(label),
+                )
+        });
+
+        let counts = draw_counts.then(|| {
+            div()
+                .flex_none()
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap(px(5.))
+                // A hair under the branch beside it, deliberately: digits have
+                // no descenders and almost no ascenders, so at one size they
+                // fill the line where the text does not and read as the bigger
+                // of the two. One step is the whole correction - at 11 px they
+                // stopped reading as the same line.
+                .text_size(px(12.))
+                .child(
+                    div()
+                        .text_color(ui.vc_added)
+                        .child(format!("+{}", stats.insertions)),
+                )
+                .child(
+                    div()
+                        .text_color(ui.vc_deleted)
+                        .child(format!("\u{2212}{}", stats.deletions)),
+                )
+        });
+
+        Some(
+            div()
+                .flex()
+                .flex_row()
+                .items_center()
+                .justify_end()
+                .gap(px(6.))
+                // Room for the larger type: 14 px clipped the descenders once
+                // the line stopped being a caption.
+                .h(px(SIDEBAR_ROW_LINE_HEIGHT))
+                // Starts under the title, not under the row's leading edge: a
+                // branch beginning at the glyph column reads as a third level
+                // of the tree rather than as a second line of this row.
+                .pl(px(indent))
+                .w(px(SIDEBAR_WORKSPACE_ROW_CONTENT_WIDTH))
+                .max_w(px(SIDEBAR_WORKSPACE_ROW_CONTENT_WIDTH))
+                .overflow_x_hidden()
+                .when_some(branch, |row, branch| row.child(branch))
+                .when_some(counts, |row, counts| row.child(counts))
+                .into_any_element(),
+        )
     }
 
     pub(crate) fn sidebar_list_wrapper(
@@ -2038,8 +2331,8 @@ mod tests {
         SIDEBAR_TAB_ICON_SIZE, SIDEBAR_TITLE_ROW_GAP, SIDEBAR_WIDTH, SidebarAgentState,
         SidebarAgentSummary, SidebarDropSlot, SidebarRow, SidebarServiceSummary,
         folder_row_sessions, reorder_target, sidebar_agent_summary, sidebar_drop_slots,
-        sidebar_row_shell, sidebar_service_summary, tab_display_title, tab_icon_cluster_split,
-        tab_row_sessions, visible_service_ports,
+        sidebar_row_shell, sidebar_service_summary, tab_diffstat_visible, tab_display_title,
+        tab_icon_cluster_split, tab_row_sessions, visible_service_ports,
     };
     use crate::agent_launcher::TerminalAgent;
     use crate::ai_types::{AgentSession, AgentState};
@@ -2053,6 +2346,37 @@ mod tests {
 
     fn session(state: AgentState) -> AgentSession {
         AgentSession::new(TerminalAgent::ClaudeCode, state)
+    }
+
+    fn show(diffstat: bool) -> paneflow_config::schema::SidebarShow {
+        paneflow_config::schema::SidebarShow {
+            branch: Some(false),
+            diffstat: Some(diffstat),
+            pr: Some(false),
+            indent_guide: Some(false),
+        }
+    }
+
+    fn dirty() -> crate::workspace::GitDiffStats {
+        crate::workspace::GitDiffStats {
+            files_changed: 3,
+            insertions: 142,
+            deletions: 38,
+        }
+    }
+
+    #[test]
+    fn the_diffstat_needs_both_a_switch_and_something_to_report() {
+        let clean = crate::workspace::GitDiffStats::default();
+        assert!(
+            !tab_diffstat_visible(show(false), &dirty()),
+            "the counts are opt-in even on a dirty checkout"
+        );
+        assert!(
+            !tab_diffstat_visible(show(true), &clean),
+            "a clean checkout prints its branch and stops"
+        );
+        assert!(tab_diffstat_visible(show(true), &dirty()));
     }
 
     #[test]

--- a/src-app/src/app/sidebar/mod.rs
+++ b/src-app/src/app/sidebar/mod.rs
@@ -1405,6 +1405,10 @@ impl PaneFlowApp {
                         tab_idx,
                         position,
                     });
+                    // Discussion #41: refresh the repository's worktree list
+                    // for the menu's Worktree section. Off the render thread,
+                    // and only on this gesture - the menu is the only reader.
+                    this.spawn_worktree_listing(ws_idx, cx);
                     cx.stop_propagation();
                     cx.notify();
                 }

--- a/src-app/src/app/tab_worktree.rs
+++ b/src-app/src/app/tab_worktree.rs
@@ -1,0 +1,426 @@
+//! Git state for a checkout that is not a workspace root.
+//!
+//! A workspace carries the branch and diffstat of its own cwd
+//! (`Workspace::git_branch` / `git_stats`). A tab bound to a worktree
+//! (discussion #41) needs the same three values for a *different* directory,
+//! and the sidebar reads them every frame - so they are cached per checkout
+//! here and refreshed by the same off-thread probes that already feed the
+//! workspace fields. Nothing in this module runs git; it only holds what the
+//! bootstrap watcher and the 30 s poll bring back.
+
+use std::collections::HashMap;
+
+use crate::PaneFlowApp;
+use crate::workspace::{GitDiffStats, worktree::WorktreeEntry};
+use gpui::Context;
+
+/// The three values a bound tab's row needs about its checkout.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct CheckoutGit {
+    /// Current branch, empty for a detached HEAD.
+    pub branch: String,
+    /// Whether the directory is inside a git repository at all.
+    pub is_repo: bool,
+    pub stats: GitDiffStats,
+}
+
+/// Per-checkout git state plus the worktree list of each repository, both
+/// keyed by absolute path.
+#[derive(Default)]
+pub(crate) struct WorktreeStates {
+    checkouts: HashMap<String, CheckoutGit>,
+    /// `git worktree list` per repository root, for the tab menu's picker.
+    listings: HashMap<String, Vec<WorktreeEntry>>,
+    /// Local branches per repository root, most recent first. What the picker
+    /// actually offers - the listing only says which of them already has a
+    /// directory.
+    branches: HashMap<String, Vec<String>>,
+}
+
+impl WorktreeStates {
+    /// Store a probe result. Returns `true` when it changed something, so the
+    /// caller only repaints on a real delta - the same contract
+    /// [`PaneFlowApp::apply_git_state_for_cwd`] already honors.
+    pub(crate) fn set_checkout(&mut self, cwd: &str, state: CheckoutGit) -> bool {
+        match self.checkouts.get(cwd) {
+            Some(current) if *current == state => false,
+            _ => {
+                self.checkouts.insert(cwd.to_string(), state);
+                true
+            }
+        }
+    }
+
+    pub(crate) fn checkout(&self, cwd: &str) -> Option<&CheckoutGit> {
+        self.checkouts.get(cwd)
+    }
+
+    pub(crate) fn set_listing(&mut self, repo_root: &str, entries: Vec<WorktreeEntry>) -> bool {
+        match self.listings.get(repo_root) {
+            Some(current) if *current == entries => false,
+            _ => {
+                self.listings.insert(repo_root.to_string(), entries);
+                true
+            }
+        }
+    }
+
+    pub(crate) fn listing(&self, repo_root: &str) -> &[WorktreeEntry] {
+        self.listings.get(repo_root).map_or(&[], Vec::as_slice)
+    }
+
+    pub(crate) fn set_branches(&mut self, repo_root: &str, branches: Vec<String>) -> bool {
+        match self.branches.get(repo_root) {
+            Some(current) if *current == branches => false,
+            _ => {
+                self.branches.insert(repo_root.to_string(), branches);
+                true
+            }
+        }
+    }
+
+    pub(crate) fn branches(&self, repo_root: &str) -> &[String] {
+        self.branches.get(repo_root).map_or(&[], Vec::as_slice)
+    }
+
+    /// Drop every entry no longer named by `live`. Called after a workspace or
+    /// tab closes so a torn-down worktree does not keep a row's worth of state
+    /// alive for the rest of the session.
+    pub(crate) fn retain_live(&mut self, live: &std::collections::HashSet<String>) {
+        self.checkouts.retain(|cwd, _| live.contains(cwd));
+        self.listings.retain(|root, _| live.contains(root));
+        self.branches.retain(|root, _| live.contains(root));
+    }
+}
+
+impl PaneFlowApp {
+    /// Every checkout worth probing: each workspace root, plus the worktree of
+    /// every bound tab. Deduplicated, so two tabs on one worktree cost one
+    /// subprocess per tick rather than two.
+    pub(crate) fn git_probe_cwds(&self) -> Vec<String> {
+        let mut seen = std::collections::HashSet::new();
+        let mut out = Vec::new();
+        for ws in &self.workspaces {
+            if !ws.cwd.is_empty() && seen.insert(ws.cwd.clone()) {
+                out.push(ws.cwd.clone());
+            }
+            for cwd in ws.bound_tab_worktrees() {
+                if seen.insert(cwd.clone()) {
+                    out.push(cwd);
+                }
+            }
+        }
+        out
+    }
+
+    /// The git state a tab's row should show, or `None` for an unbound tab
+    /// (which has no identity of its own to report) or one whose first probe
+    /// has not landed yet.
+    pub(crate) fn tab_checkout_git(&self, tab: &crate::workspace::Tab) -> Option<&CheckoutGit> {
+        let path = tab.worktree.as_ref()?;
+        self.worktree_states.checkout(&path.to_string_lossy())
+    }
+
+    /// The checkout the active tab works in: its worktree when bound, the
+    /// workspace root otherwise.
+    ///
+    /// The git surfaces read this rather than `ws.cwd` so they follow the tab
+    /// the user is looking at - the same move Zed makes when it recomputes its
+    /// active repository from the focused item
+    /// (`crates/workspace/src/workspace.rs`, `active_item_path_changed`),
+    /// except that here the unit is the tab rather than the window.
+    pub(crate) fn active_checkout(&self) -> Option<String> {
+        let ws = self.active_workspace()?;
+        ws.active_tab()
+            .worktree
+            .as_ref()
+            .map(|path| path.to_string_lossy().into_owned())
+            .or_else(|| (!ws.cwd.is_empty()).then(|| ws.cwd.clone()))
+    }
+
+    /// The checkout a pane belongs to: the worktree of the tab holding it when
+    /// that tab is bound, otherwise its workspace's root.
+    pub(crate) fn checkout_for_pane(
+        &self,
+        pane: &gpui::Entity<crate::pane::Pane>,
+    ) -> Option<String> {
+        let ws = self
+            .workspaces
+            .iter()
+            .find(|ws| ws.tab_for_pane(pane).is_some())?;
+        ws.tab_for_pane(pane)
+            .and_then(|tab| tab.worktree.as_ref())
+            .map(|path| path.to_string_lossy().into_owned())
+            .or_else(|| (!ws.cwd.is_empty()).then(|| ws.cwd.clone()))
+    }
+
+    /// What to call a workspace's own checkout in a worktree picker.
+    ///
+    /// Its branch, taken from the worktree listing when it has arrived and
+    /// from the workspace's own git state otherwise - the two agree, the
+    /// listing is only more precise about a detached HEAD. "Project root" is
+    /// the last resort, for a workspace that is not in a repository at all.
+    pub(crate) fn workspace_checkout_label(&self, ws_idx: usize) -> String {
+        let Some(ws) = self.workspaces.get(ws_idx) else {
+            return "Project root".to_string();
+        };
+        let root = &ws.worktree_root;
+        self.workspace_worktree_listing(ws_idx)
+            .iter()
+            .find(|entry| entry.path == *root)
+            .map(|entry| {
+                crate::workspace::worktree::checkout_label(entry.branch.as_deref(), root, root)
+            })
+            .filter(|label| !label.is_empty())
+            .or_else(|| (!ws.git_branch.is_empty()).then(|| ws.git_branch.clone()))
+            .unwrap_or_else(|| "Project root".to_string())
+    }
+
+    /// Bind `tab_idx` to `worktree`, or unbind it with `None`.
+    ///
+    /// The binding takes effect for panes opened *after* it: an existing pane
+    /// keeps the shell it already has, because moving a live process between
+    /// checkouts is not something Paneflow can do behind the user's back. What
+    /// changes immediately is the row's identity and where the next pane lands.
+    pub(crate) fn set_tab_worktree(
+        &mut self,
+        ws_idx: usize,
+        tab_idx: usize,
+        worktree: Option<std::path::PathBuf>,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(ws) = self.workspaces.get_mut(ws_idx) else {
+            return;
+        };
+        let ws_id = ws.id;
+        let Some(tab) = ws.tab_mut(tab_idx) else {
+            return;
+        };
+        if tab.worktree == worktree {
+            return;
+        }
+        tab.worktree = worktree.clone();
+        // Probe the new checkout now rather than waiting up to 30 s for the
+        // poll: a row that names a branch only after half a minute reads as
+        // broken.
+        if let Some(path) = worktree {
+            Self::spawn_initial_git_stats(ws_id, path.to_string_lossy().into_owned(), cx);
+        }
+        self.save_session(cx);
+        cx.notify();
+    }
+
+    /// Refresh what the checkout picker offers for a workspace's repository -
+    /// its local branches, and which of them already has a worktree - off the
+    /// render thread. Called when a picker opens: both are plumbing reads, but
+    /// they are still subprocesses.
+    pub(crate) fn spawn_worktree_listing(&mut self, ws_idx: usize, cx: &mut Context<Self>) {
+        let Some(repo_root) = self
+            .workspaces
+            .get(ws_idx)
+            .and_then(|ws| ws.repo_root.clone())
+        else {
+            return;
+        };
+        let key = repo_root.to_string_lossy().into_owned();
+        cx.spawn(
+            async move |this: gpui::WeakEntity<Self>, cx: &mut gpui::AsyncApp| {
+                let probe = repo_root.clone();
+                let read = smol::unblock(move || {
+                    (
+                        crate::workspace::worktree::list_worktrees(&probe),
+                        crate::workspace::worktree::list_branches(&probe),
+                    )
+                })
+                .await;
+                let _ = cx.update(|cx| {
+                    this.update(cx, |app: &mut Self, cx: &mut Context<Self>| {
+                        let mut changed = false;
+                        if let Ok(entries) = read.0 {
+                            changed |= app.worktree_states.set_listing(&key, entries);
+                        }
+                        if let Ok(branches) = read.1 {
+                            changed |= app.worktree_states.set_branches(&key, branches);
+                        }
+                        if changed {
+                            cx.notify();
+                        }
+                    })
+                });
+            },
+        )
+        .detach();
+    }
+
+    /// The branches offered for a workspace's tabs, as last read.
+    pub(crate) fn workspace_branches(&self, ws_idx: usize) -> &[String] {
+        self.workspaces
+            .get(ws_idx)
+            .and_then(|ws| ws.repo_root.as_ref())
+            .map_or(&[], |root| {
+                self.worktree_states.branches(&root.to_string_lossy())
+            })
+    }
+
+    /// Point a tab at a branch, making its worktree if the branch has none.
+    ///
+    /// This is the whole point of the picker: the user picks a branch, and
+    /// whether that branch already has a directory is git's problem, not
+    /// theirs. Selecting the branch the repository itself is on unbinds the
+    /// tab instead of duplicating that checkout - git would refuse the second
+    /// worktree anyway.
+    ///
+    /// The work runs off the render thread (a checkout can take seconds on a
+    /// large repository) and re-resolves the tab by id when it lands, because
+    /// indices do not survive an await.
+    pub(crate) fn bind_tab_to_branch(
+        &mut self,
+        ws_idx: usize,
+        tab_idx: usize,
+        branch: String,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(ws) = self.workspaces.get(ws_idx) else {
+            return;
+        };
+        let Some(repo_root) = ws.repo_root.clone() else {
+            return;
+        };
+        let Some(tab_id) = ws.tabs().get(tab_idx).map(|tab| tab.id) else {
+            return;
+        };
+        let ws_id = ws.id;
+        // A branch the listing already places needs no subprocess: bind now,
+        // so the common case stays a single frame.
+        if let Some(entry) = self
+            .workspace_worktree_listing(ws_idx)
+            .iter()
+            .find(|entry| entry.branch.as_deref() == Some(branch.as_str()))
+        {
+            let path = (entry.path != repo_root).then(|| entry.path.clone());
+            self.set_tab_worktree(ws_idx, tab_idx, path, cx);
+            return;
+        }
+
+        self.branch_checkout_pending = Some(branch.clone());
+        cx.notify();
+        cx.spawn(
+            async move |this: gpui::WeakEntity<Self>, cx: &mut gpui::AsyncApp| {
+                let probe = repo_root.clone();
+                let name = branch.clone();
+                let prepared = smol::unblock(move || {
+                    crate::workspace::worktree::prepare_branch_checkout(&probe, &name)
+                })
+                .await;
+                let _ = cx.update(|cx| {
+                    this.update(cx, |app: &mut Self, cx: &mut Context<Self>| {
+                        app.branch_checkout_pending = None;
+                        match prepared {
+                            Ok(path) => {
+                                let Some((ws_idx, tab_idx)) = app.tab_position(ws_id, tab_id)
+                                else {
+                                    cx.notify();
+                                    return;
+                                };
+                                let path = (path != repo_root).then_some(path);
+                                app.set_tab_worktree(ws_idx, tab_idx, path, cx);
+                                app.spawn_worktree_listing(ws_idx, cx);
+                            }
+                            Err(message) => app.show_toast(message, cx),
+                        }
+                        cx.notify();
+                    })
+                });
+            },
+        )
+        .detach();
+    }
+
+    /// Locate a tab by the ids that survive an await, unlike its indices.
+    pub(crate) fn tab_position(&self, ws_id: u64, tab_id: u64) -> Option<(usize, usize)> {
+        let ws_idx = self.workspaces.iter().position(|ws| ws.id == ws_id)?;
+        let tab_idx = self.workspaces[ws_idx]
+            .tabs()
+            .iter()
+            .position(|tab| tab.id == tab_id)?;
+        Some((ws_idx, tab_idx))
+    }
+
+    /// The worktrees offered for a workspace's tabs: what `git worktree list`
+    /// last reported for its repository.
+    pub(crate) fn workspace_worktree_listing(&self, ws_idx: usize) -> &[WorktreeEntry] {
+        self.workspaces
+            .get(ws_idx)
+            .and_then(|ws| ws.repo_root.as_ref())
+            .map_or(&[], |root| {
+                self.worktree_states.listing(&root.to_string_lossy())
+            })
+    }
+
+    /// Forget the state of every checkout no longer open.
+    pub(crate) fn prune_worktree_states(&mut self) {
+        let live: std::collections::HashSet<String> = self
+            .git_probe_cwds()
+            .into_iter()
+            .chain(
+                self.workspaces
+                    .iter()
+                    .filter_map(|ws| ws.worktree_root.to_str().map(str::to_string)),
+            )
+            .collect();
+        self.worktree_states.retain_live(&live);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CheckoutGit, WorktreeStates};
+    use crate::workspace::GitDiffStats;
+
+    fn state(branch: &str, insertions: usize) -> CheckoutGit {
+        CheckoutGit {
+            branch: branch.to_string(),
+            is_repo: true,
+            stats: GitDiffStats {
+                files_changed: 1,
+                insertions,
+                deletions: 0,
+            },
+        }
+    }
+
+    #[test]
+    fn a_repeated_probe_reports_no_change() {
+        let mut states = WorktreeStates::default();
+        assert!(states.set_checkout("/w/a", state("main", 3)));
+        assert!(
+            !states.set_checkout("/w/a", state("main", 3)),
+            "an identical probe must not ask the rail to repaint"
+        );
+        assert!(states.set_checkout("/w/a", state("main", 4)));
+        assert!(states.set_checkout("/w/a", state("feat/x", 4)));
+    }
+
+    #[test]
+    fn checkouts_are_independent_and_prunable() {
+        let mut states = WorktreeStates::default();
+        states.set_checkout("/w/a", state("main", 1));
+        states.set_checkout("/w/b", state("feat/x", 9));
+        assert_eq!(
+            states.checkout("/w/b").map(|s| s.branch.as_str()),
+            Some("feat/x")
+        );
+        assert!(
+            states.checkout("/w/missing").is_none(),
+            "an unprobed checkout reports nothing rather than a stale neighbor"
+        );
+
+        let live = std::collections::HashSet::from(["/w/a".to_string()]);
+        states.retain_live(&live);
+        assert!(states.checkout("/w/a").is_some());
+        assert!(
+            states.checkout("/w/b").is_none(),
+            "closing a tab must not leave its worktree state alive for the session"
+        );
+    }
+}

--- a/src-app/src/app/workspace_ops/mod.rs
+++ b/src-app/src/app/workspace_ops/mod.rs
@@ -217,6 +217,8 @@ impl PaneFlowApp {
         self.title_bar_files_menu_open = None;
         self.title_bar_help_menu_open = None;
         self.workspace_menu_open = None;
+        self.sidebar_customize_menu_open = false;
+        self.sidebar_show_submenu_open = false;
         self.tab_menu_open = None;
         self.pane_menu_open = None;
         self.profile_menu_open = None;

--- a/src-app/src/app/workspace_ops/mod.rs
+++ b/src-app/src/app/workspace_ops/mod.rs
@@ -182,6 +182,17 @@ impl PaneFlowApp {
                 }
             }
         }
+        // The same result also answers for a tab bound to this checkout, which
+        // is not necessarily any workspace's root - so the probe is stored
+        // whether or not a workspace matched.
+        changed |= self.worktree_states.set_checkout(
+            cwd,
+            crate::app::tab_worktree::CheckoutGit {
+                branch,
+                is_repo,
+                stats,
+            },
+        );
         changed
     }
 
@@ -326,7 +337,7 @@ impl PaneFlowApp {
     /// switch (re-target) and close (Multi-project group reconcile). Deferred so
     /// the rebuild (which mounts a fresh entity) never runs inside a
     /// render/callback. No-op outside Diff mode.
-    fn reconcile_diff_after_workspace_change(&self, cx: &mut Context<Self>) {
+    pub(crate) fn reconcile_diff_after_workspace_change(&self, cx: &mut Context<Self>) {
         if matches!(self.mode, paneflow_config::schema::AppMode::Diff) {
             let weak = cx.weak_entity();
             cx.defer(move |cx| {
@@ -461,9 +472,16 @@ impl PaneFlowApp {
         &self,
         source_cwd: Option<std::path::PathBuf>,
     ) -> Option<std::path::PathBuf> {
-        source_cwd.or_else(|| {
-            self.active_workspace()
-                .map(|ws| ws.cwd.as_str())
+        let Some(ws) = self.active_workspace() else {
+            return source_cwd;
+        };
+        // A bound tab confines every pane opened in it to its worktree
+        // (discussion #41). This is the single choke point every in-app pane
+        // creation goes through, which is why the rule lives here rather than
+        // being repeated at each call site.
+        let confined = ws.active_tab().confine_cwd(source_cwd);
+        confined.or_else(|| {
+            Some(ws.cwd.as_str())
                 .filter(|cwd| !cwd.is_empty())
                 .map(std::path::PathBuf::from)
         })
@@ -645,8 +663,11 @@ impl PaneFlowApp {
             && ws.active_tab().root.is_none()
         {
             let ws_id = ws.id;
-            let cwd = std::path::PathBuf::from(&ws.cwd);
-            let terminal = cx.new(|cx| TerminalView::with_cwd(ws_id, Some(cwd), None, cx));
+            // Through `new_terminal_cwd` rather than straight from `ws.cwd`:
+            // respawning the last pane of a bound tab must land back in that
+            // tab's worktree, not at the workspace root.
+            let cwd = self.new_terminal_cwd(None);
+            let terminal = cx.new(|cx| TerminalView::with_cwd(ws_id, cwd, None, cx));
             // US-028: do NOT subscribe here - `create_pane` already wires
             // `handle_terminal_event` (main.rs:539). The duplicate subscription
             // fired every terminal event twice (double toast / port-scan /
@@ -798,6 +819,8 @@ impl PaneFlowApp {
         // US-009: this workspace's managed worktrees are torn down (clean
         // ones only) in the background once the workspace is gone.
         let worktrees = std::mem::take(&mut self.workspaces[idx].managed_worktrees);
+        // Every checkout this workspace's tabs were bound to leaves with it.
+        self.prune_worktree_states();
         Self::spawn_worktree_teardown(worktrees, cx);
         self.workspaces.remove(idx);
         if self.workspaces.is_empty() {

--- a/src-app/src/app/workspace_ops/tab.rs
+++ b/src-app/src/app/workspace_ops/tab.rs
@@ -51,7 +51,19 @@ impl PaneFlowApp {
             return false;
         };
         let ws_id = ws.id;
-        let cwd = (!ws.cwd.is_empty()).then(|| std::path::PathBuf::from(&ws.cwd));
+        // The active tab is the one this surface lands in when it is empty (the
+        // palette's own tab, and any tab whose last pane closed), so its
+        // worktree binding decides the cwd. A surface that opens a NEW tab
+        // instead starts unbound, at the workspace root. Reading `ws.cwd`
+        // directly here was the one pane-creation path that bypassed
+        // `Tab::confine_cwd`, which meant an agent picked from the palette in a
+        // bound tab spawned in the wrong checkout.
+        let fills_active_tab =
+            ws.active_tab().root.is_none() && ws.active_tab().saved_layout.is_none();
+        let cwd = fills_active_tab
+            .then(|| ws.active_tab().worktree.clone())
+            .flatten()
+            .or_else(|| (!ws.cwd.is_empty()).then(|| std::path::PathBuf::from(&ws.cwd)));
         // A preset label reaches the sidebar verbatim, and a custom command's
         // name is user input: strip CLI decoration (spinners, zero-width
         // glyphs) the way every other title path does.
@@ -200,12 +212,21 @@ impl PaneFlowApp {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // Discussion #41: a tab bound to a worktree reviews that checkout, so
+        // switching tab inside the active workspace can change what Diff mode
+        // is looking at - which the workspace-switch reconcile below never
+        // covers, because the workspace did not change. The dock needs no help:
+        // it already parks and restores per tab id.
+        let checkout_before = self.active_checkout();
         if let Some(ws) = self.workspaces.get_mut(ws_idx) {
             ws.set_active_tab(tab_idx);
         }
         if ws_idx == self.active_idx {
             self.workspaces[ws_idx].focus_first(window, cx);
             self.save_session(cx);
+            if self.active_checkout() != checkout_before {
+                self.reconcile_diff_after_workspace_change(cx);
+            }
         } else {
             self.select_workspace(ws_idx, window, cx);
         }
@@ -278,6 +299,10 @@ impl PaneFlowApp {
         // own reconcile never runs: its parked slot (and the terminals in it)
         // would outlive the session it belonged to.
         self.prune_parked_diff_docks();
+        // The closed tab may have been the last reader of a worktree's git
+        // state. The checkout itself is left alone: tearing it down is a
+        // separate, destructive decision.
+        self.prune_worktree_states();
     }
 
     pub(crate) fn handle_close_tab(

--- a/src-app/src/app/workspace_ops/tab.rs
+++ b/src-app/src/app/workspace_ops/tab.rs
@@ -20,11 +20,14 @@ use crate::workspace::Tab;
 use crate::{CloseTab, NewTab, NextTab, PreviousTab, TabDrag};
 
 impl PaneFlowApp {
-    /// US-008: toggle the sidebar folder row for `ws_idx`. Session-only state,
-    /// so nothing is persisted.
+    /// US-008: toggle the sidebar folder row for `ws_idx`.
+    ///
+    /// Persisted: a fold you made on purpose has to survive a restart, or
+    /// closing ten folders and reopening two is a chore you redo every launch.
     pub(crate) fn toggle_workspace_expanded(&mut self, ws_idx: usize, cx: &mut Context<Self>) {
         if let Some(ws) = self.workspaces.get_mut(ws_idx) {
             ws.sidebar_expanded = !ws.sidebar_expanded;
+            self.save_session(cx);
             cx.notify();
         }
     }

--- a/src-app/src/main.rs
+++ b/src-app/src/main.rs
@@ -1081,6 +1081,14 @@ struct PaneFlowApp {
     /// time: the picker names it while git works, and refuses to launch a pane
     /// that would otherwise start in the checkout being left behind.
     pub(crate) branch_checkout_pending: Option<String>,
+    /// Pull request of each branch the rail shows, behind the `PR` switch.
+    /// Read through `gh`, cached per (repository, branch).
+    pub(crate) pr_states: crate::app::pull_request::PrStates,
+    /// Whether the rail header's Customize Sidebar popover is up.
+    pub(crate) sidebar_customize_menu_open: bool,
+    /// Whether that popover's "Show" submenu is unfolded. Closing the parent
+    /// folds it, so the menu always reopens collapsed.
+    pub(crate) sidebar_show_submenu_open: bool,
     /// US-010: right-click menu on a sidebar tab row (Rename / Close).
     tab_menu_open: Option<TabContextMenu>,
     /// Pane header context menu (EP-002 US-007), or `None` when closed.

--- a/src-app/src/main.rs
+++ b/src-app/src/main.rs
@@ -1072,6 +1072,15 @@ struct PaneFlowApp {
     theme_mode: ThemeMode,
     /// Workflow action menu currently open in the sidebar (`None` = closed).
     workspace_menu_open: Option<WorkspaceContextMenu>,
+    /// Git state of every checkout that is not a workspace root: the worktree
+    /// of each bound tab (discussion #41), plus each repository's worktree
+    /// list for the tab menu's picker. Filled by the same off-thread probes
+    /// that feed `Workspace::git_branch`.
+    pub(crate) worktree_states: crate::app::tab_worktree::WorktreeStates,
+    /// Branch whose worktree is being checked out right now, if any. One at a
+    /// time: the picker names it while git works, and refuses to launch a pane
+    /// that would otherwise start in the checkout being left behind.
+    pub(crate) branch_checkout_pending: Option<String>,
     /// US-010: right-click menu on a sidebar tab row (Rename / Close).
     tab_menu_open: Option<TabContextMenu>,
     /// Pane header context menu (EP-002 US-007), or `None` when closed.

--- a/src-app/src/workspace/mod.rs
+++ b/src-app/src/workspace/mod.rs
@@ -15,7 +15,9 @@ pub mod surface_naming;
 mod tab;
 pub mod worktree;
 
-pub use git::{GitDiffStats, detect_branch, find_git_dir, resolve_repo_root};
+pub use git::{
+    GitDiffStats, detect_branch, find_git_dir, resolve_repo_root, resolve_worktree_root,
+};
 #[cfg(test)]
 pub(crate) use ports::PortEntry;
 pub use ports::{PaneScan, scan_panes};
@@ -303,6 +305,12 @@ impl Workspace {
     }
 
     /// Create a workspace with a pre-allocated ID and layout tree.
+    /// Test-only since `workspace.up` started building its tabs itself: every
+    /// production path either restores a set of tabs
+    /// ([`Self::restored_with_id`]) or goes through the workspace constructors
+    /// above. Kept because a one-tab workspace is what most tests want to
+    /// assert against.
+    #[cfg(test)]
     pub fn with_layout_and_id(
         id: u64,
         title: impl Into<String>,
@@ -529,6 +537,24 @@ impl Workspace {
     ///
     /// This is what `session.json` v2 stores: the whole tab list, not just the
     /// tab that happened to be visible at save time.
+    /// The tab holding `pane`, or `None` when no tab of this workspace does.
+    /// Used to resolve which checkout a pane belongs to: with a tab bound to a
+    /// worktree, that is the tab's, not the workspace's.
+    pub fn tab_for_pane(&self, pane: &gpui::Entity<Pane>) -> Option<&Tab> {
+        self.tabs.iter().find(|tab| tab.contains_pane(pane))
+    }
+
+    /// The worktree of every tab bound to one, as absolute path strings.
+    /// Feeds the git probe set: a bound tab needs its own branch and diffstat,
+    /// which the workspace's own fields cannot answer.
+    pub fn bound_tab_worktrees(&self) -> Vec<String> {
+        self.tabs
+            .iter()
+            .filter_map(|tab| tab.worktree.as_ref())
+            .map(|path| path.to_string_lossy().into_owned())
+            .collect()
+    }
+
     pub fn serialize_tabs_without_scrollback(&self, cx: &App) -> Vec<TabSession> {
         self.tabs
             .iter()
@@ -536,6 +562,10 @@ impl Workspace {
                 title: tab.title().to_string(),
                 title_source: Some(tab.title_source()),
                 layout: tab.serialize_without_scrollback(cx),
+                worktree: tab
+                    .worktree
+                    .as_ref()
+                    .map(|path| path.to_string_lossy().into_owned()),
             })
             .collect()
     }

--- a/src-app/src/workspace/tab.rs
+++ b/src-app/src/workspace/tab.rs
@@ -41,6 +41,27 @@ pub struct Tab {
     /// Saved layout tree while zoomed. `Some(tree)` means this tab is zoomed
     /// and `root` holds only the zoomed pane as a single Leaf.
     pub saved_layout: Option<LayoutTree>,
+    /// The git worktree this tab works in, or `None` for an unbound tab.
+    ///
+    /// This is the tab's git identity, in the sense discussion #41 asks for:
+    /// bound, every pane opened in the tab starts in this checkout, and the
+    /// sidebar row names the branch it sits on. Unbound, the tab behaves
+    /// exactly as it always has and its row says nothing extra - which is what
+    /// makes the line signal rather than chrome, since it only appears where it
+    /// tells two tabs apart.
+    ///
+    /// The same unit as a Cursor agent and a Codex chat, both of which carry
+    /// the worktree on the session rather than on the window. Zed is the
+    /// counter-example: its active repository is one field per window
+    /// (`crates/project/src/git_store.rs`, `active_repo_id`), recomputed from
+    /// the focused item, and it opens a *window* per worktree - the opposite of
+    /// several agents side by side in one.
+    ///
+    /// A path, not a branch name: a branch can only be checked out in one
+    /// worktree at a time, the checkout directory is what a pane actually needs
+    /// to spawn in, and a detached-HEAD worktree (what the Codex app creates by
+    /// default) has no branch at all. The branch is derived for display.
+    pub worktree: Option<std::path::PathBuf>,
     /// Whether this tab wants the docked Files rail on screen.
     ///
     /// The rail itself is a single app-level surface (one tree, one watcher),
@@ -68,6 +89,7 @@ impl Tab {
             title_source: TabTitleSource::Preset,
             root,
             saved_layout: None,
+            worktree: None,
             files_sidebar_open: false,
         }
     }
@@ -80,10 +102,31 @@ impl Tab {
         title: impl Into<String>,
         title_source: TabTitleSource,
         root: Option<LayoutTree>,
+        worktree: Option<std::path::PathBuf>,
     ) -> Self {
         Self {
             title_source,
+            worktree,
             ..Self::new(title, root)
+        }
+    }
+
+    /// The cwd a pane opened in this tab must start in, given the cwd it would
+    /// otherwise have inherited.
+    ///
+    /// An unbound tab keeps `inherited` untouched. A bound tab keeps it only
+    /// while it stays inside its own checkout - splitting from a pane sitting
+    /// in `src/` must land in `src/`, not back at the root - and pulls anything
+    /// outside back to the worktree. That last clause is the whole safety
+    /// property: without it a `cd` in one pane leaks into every pane opened
+    /// after it, and the binding is decoration.
+    pub fn confine_cwd(&self, inherited: Option<std::path::PathBuf>) -> Option<std::path::PathBuf> {
+        let Some(worktree) = self.worktree.as_ref() else {
+            return inherited;
+        };
+        match inherited {
+            Some(cwd) if cwd.starts_with(worktree) => Some(cwd),
+            _ => Some(worktree.clone()),
         }
     }
 
@@ -431,6 +474,49 @@ mod tests {
     fn a_freshly_built_tab_is_app_named() {
         assert!(!tab("Claude Code").title_is_user_owned());
         assert!(!Tab::empty().title_is_user_owned());
-        assert!(Tab::restored("sprint 3", TabTitleSource::User, None).title_is_user_owned());
+        assert!(Tab::restored("sprint 3", TabTitleSource::User, None, None).title_is_user_owned());
+    }
+
+    #[test]
+    fn an_unbound_tab_inherits_whatever_it_was_given() {
+        let tab = Tab::new("free", None);
+        let inherited = std::path::PathBuf::from("/anywhere/at/all");
+        assert_eq!(tab.confine_cwd(Some(inherited.clone())), Some(inherited));
+        assert_eq!(tab.confine_cwd(None), None);
+    }
+
+    #[test]
+    fn a_bound_tab_confines_every_pane_to_its_worktree() {
+        let worktree = std::path::PathBuf::from("/repo.worktrees/feat-login");
+        let tab = Tab::restored(
+            "login",
+            TabTitleSource::Preset,
+            None,
+            Some(worktree.clone()),
+        );
+
+        // Splitting from a pane deeper inside the same checkout keeps that
+        // directory: the boundary is the worktree, not its root.
+        let inside = worktree.join("src/auth");
+        assert_eq!(tab.confine_cwd(Some(inside.clone())), Some(inside));
+
+        // A pane that wandered out - a `cd` to the main checkout, to a sibling
+        // worktree, to anywhere - does not drag the next pane out with it.
+        // Without this the binding is decoration.
+        assert_eq!(
+            tab.confine_cwd(Some(std::path::PathBuf::from("/repo"))),
+            Some(worktree.clone())
+        );
+        assert_eq!(
+            tab.confine_cwd(Some(std::path::PathBuf::from(
+                "/repo.worktrees/feat-billing"
+            ))),
+            Some(worktree.clone()),
+            "a sibling worktree is outside, however similar its path looks"
+        );
+
+        // Nothing inherited at all still lands in the worktree, never at the
+        // process cwd.
+        assert_eq!(tab.confine_cwd(None), Some(worktree));
     }
 }

--- a/src-app/src/workspace/worktree.rs
+++ b/src-app/src/workspace/worktree.rs
@@ -142,6 +142,30 @@ pub struct WorktreeEntry {
     pub branch: Option<String>,
 }
 
+/// Display name for a checkout: its branch, or a directory name when HEAD is
+/// detached.
+///
+/// Detached is not an edge case - `git worktree add --detach` leaves that
+/// state, the Codex app creates every one of its worktrees that way, and agent
+/// tooling that lays checkouts out as `<...>/<slug>/<repo>` produces a
+/// directory whose own name is just the repository's, identical for every
+/// worktree. So when the last component repeats the repository's name, the
+/// parent is what actually distinguishes this checkout and the label uses it.
+pub fn checkout_label(branch: Option<&str>, path: &Path, repo_root: &Path) -> String {
+    if let Some(branch) = branch.filter(|b| !b.is_empty()) {
+        return branch.to_string();
+    }
+    let name = path.file_name();
+    if name.is_some()
+        && name == repo_root.file_name()
+        && let Some(parent) = path.parent().and_then(Path::file_name)
+    {
+        return parent.to_string_lossy().into_owned();
+    }
+    name.map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
 /// Filesystem-safe directory name for a branch (`feat/x` → `feat-x`).
 /// Conservative whitelist: anything outside `[A-Za-z0-9._-]` becomes `-`.
 /// Leading/trailing `-` AND `.` are trimmed: a dot-only branch (`.`/`..`)
@@ -279,6 +303,104 @@ pub fn branch_exists(repo_root: &Path, branch: &str) -> bool {
         GIT_DEADLINE,
     )
     .is_ok()
+}
+
+/// Local branches, most recently committed first.
+///
+/// The picker offers branches, not worktrees: a worktree is how git gives a
+/// second branch a directory, and it is the branch the user is choosing
+/// between. Ordering by commit date puts the ones actually being worked on at
+/// the top, where a repository with fifty branches needs them.
+pub fn list_branches(repo_root: &Path) -> Result<Vec<String>, String> {
+    let stdout = run_git(
+        repo_root,
+        &[
+            "for-each-ref",
+            "--format=%(refname:short)",
+            "--sort=-committerdate",
+            "refs/heads",
+        ],
+        GIT_DEADLINE,
+    )?;
+    Ok(stdout
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+/// Where a chosen branch's checkout is, or has to be made.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BranchCheckout {
+    /// A worktree already holds the branch - bind to it, create nothing.
+    Existing(PathBuf),
+    /// Nothing holds it yet; this is where its worktree belongs.
+    Create(PathBuf),
+}
+
+/// Resolve a branch to a checkout directory, without touching the filesystem.
+///
+/// Split from [`prepare_branch_checkout`] so the collision rules are testable
+/// without a repository. `Existing` first: git refuses a second worktree on the
+/// same branch, so reusing the one that holds it is the only way selecting an
+/// already-checked-out branch can work at all.
+pub fn plan_branch_checkout(
+    entries: &[WorktreeEntry],
+    repo_root: &Path,
+    branch: &str,
+) -> Result<BranchCheckout, String> {
+    if let Some(entry) = entries
+        .iter()
+        .find(|entry| entry.branch.as_deref() == Some(branch))
+    {
+        return Ok(BranchCheckout::Existing(entry.path.clone()));
+    }
+    let legacy = worktree_dir(repo_root, branch);
+    let path = if entries.iter().any(|entry| entry.path == legacy) {
+        worktree_dir_hashed(repo_root, branch)
+    } else {
+        legacy
+    };
+    if let Some(entry) = entries.iter().find(|entry| entry.path == path) {
+        return Err(format!(
+            "{} exists but holds another branch ({})",
+            path.display(),
+            entry.branch.as_deref().unwrap_or("detached")
+        ));
+    }
+    Ok(BranchCheckout::Create(path))
+}
+
+/// The directory to work in for `branch`: the worktree that already holds it,
+/// or a new sibling worktree checked out from it.
+///
+/// Blocking (two to three git subprocesses, one of them a full checkout) - the
+/// caller runs it through `smol::unblock`.
+///
+/// The result is deliberately NOT recorded as a [`ManagedWorktree`]: teardown
+/// is for the checkouts orchestration creates behind the user's back, and a
+/// directory asked for by name, by hand, is the user's. Nothing here removes
+/// it, and the branch is untouched either way.
+pub fn prepare_branch_checkout(repo_root: &Path, branch: &str) -> Result<PathBuf, String> {
+    let entries = list_worktrees(repo_root)?;
+    match plan_branch_checkout(&entries, repo_root, branch)? {
+        BranchCheckout::Existing(path) => Ok(path),
+        BranchCheckout::Create(path) => {
+            if path.exists() {
+                return Err(format!(
+                    "{} exists but is not a registered worktree; remove it first",
+                    path.display()
+                ));
+            }
+            add_worktree(repo_root, &path, branch, false)?;
+            // Same courtesy `paneflow up` extends its worktrees: a checkout
+            // without the repository's gitignored `.env*` cannot run the app
+            // it holds.
+            copy_env_files(repo_root, &path);
+            Ok(path)
+        }
+    }
 }
 
 /// `git worktree add <path> [-b] <branch>`. `create_branch` chooses between
@@ -436,6 +558,77 @@ mod tests {
     }
 
     #[test]
+    fn a_branch_already_checked_out_is_reused_never_recreated() {
+        let repo = Path::new("/home/a/dev/paneflow");
+        let entries = vec![
+            WorktreeEntry {
+                path: repo.to_path_buf(),
+                branch: Some("main".to_string()),
+            },
+            WorktreeEntry {
+                path: PathBuf::from("/home/a/dev/paneflow.worktrees/feat-x"),
+                branch: Some("feat/x".to_string()),
+            },
+        ];
+        // git refuses a second worktree on one branch, so the only workable
+        // answer for an already-checked-out branch is the checkout it is in -
+        // including the repository's own, which is how selecting `main` unbinds.
+        assert_eq!(
+            plan_branch_checkout(&entries, repo, "feat/x"),
+            Ok(BranchCheckout::Existing(PathBuf::from(
+                "/home/a/dev/paneflow.worktrees/feat-x"
+            )))
+        );
+        assert_eq!(
+            plan_branch_checkout(&entries, repo, "main"),
+            Ok(BranchCheckout::Existing(repo.to_path_buf()))
+        );
+        assert_eq!(
+            plan_branch_checkout(&entries, repo, "chore/rust-1.98"),
+            Ok(BranchCheckout::Create(PathBuf::from(
+                "/home/a/dev/paneflow.worktrees/chore-rust-1.98"
+            )))
+        );
+    }
+
+    #[test]
+    fn a_slug_collision_falls_back_to_the_hashed_dir() {
+        let repo = Path::new("/home/a/dev/paneflow");
+        // `feat/x` and `feat-x` slugify the same; the second one asked for
+        // takes the hashed path rather than the occupied one.
+        let entries = vec![WorktreeEntry {
+            path: worktree_dir(repo, "feat/x"),
+            branch: Some("feat/x".to_string()),
+        }];
+        assert_eq!(
+            plan_branch_checkout(&entries, repo, "feat-x"),
+            Ok(BranchCheckout::Create(worktree_dir_hashed(repo, "feat-x")))
+        );
+    }
+
+    #[test]
+    fn a_registered_checkout_on_the_target_path_is_refused_not_overwritten() {
+        let repo = Path::new("/home/a/dev/paneflow");
+        // Both candidate paths are taken by checkouts of something else (a
+        // detached HEAD names no branch, so neither matches by branch).
+        let entries = vec![
+            WorktreeEntry {
+                path: worktree_dir(repo, "feat/x"),
+                branch: None,
+            },
+            WorktreeEntry {
+                path: worktree_dir_hashed(repo, "feat/x"),
+                branch: None,
+            },
+        ];
+        let planned = plan_branch_checkout(&entries, repo, "feat/x");
+        assert!(
+            planned.is_err(),
+            "a registered checkout on the target path must never be written over: {planned:?}"
+        );
+    }
+
+    #[test]
     fn worktree_dir_is_a_sibling_of_the_repo() {
         let dir = worktree_dir(Path::new("/home/a/dev/paneflow"), "feat/x");
         assert_eq!(dir, PathBuf::from("/home/a/dev/paneflow.worktrees/feat-x"));
@@ -576,5 +769,34 @@ mod tests {
         let dst = tempfile::tempdir().expect("dst");
         let copied = copy_env_files(Path::new("/nonexistent-paneflow-test"), dst.path());
         assert!(copied.is_empty());
+    }
+
+    #[test]
+    fn a_detached_checkout_is_named_by_what_distinguishes_it() {
+        let repo = Path::new("/home/u/dev/paneflow");
+        assert_eq!(
+            checkout_label(Some("feat/login"), Path::new("/wt/feat-login"), repo),
+            "feat/login"
+        );
+        // The layout agent tooling produces: every worktree directory is named
+        // after the repository, so the last component says nothing.
+        assert_eq!(
+            checkout_label(
+                None,
+                Path::new("/home/u/dev/worktrees/paneflow/poplar-plume/paneflow"),
+                repo
+            ),
+            "poplar-plume"
+        );
+        // A directory that already differs is kept as-is.
+        assert_eq!(
+            checkout_label(None, Path::new("/wt/hotfix-42"), repo),
+            "hotfix-42"
+        );
+        // An empty branch is a detached HEAD, not a branch named "".
+        assert_eq!(
+            checkout_label(Some(""), Path::new("/wt/hotfix-42"), repo),
+            "hotfix-42"
+        );
     }
 }


### PR DESCRIPTION
Builds on the work #46 started: the rail can now say more about a tab, and a
tab can now stand somewhere of its own. Two commits, two subjects.

## A tab is bound to its own worktree

A workspace was one checkout, so every one of its tabs reported the same
branch and the same counts. Now a tab can be bound to a worktree of its own.

The "New pane" palette and the tab context menu list the repository's
**branches**, not just its existing worktrees, because a branch is what the
user thinks in. Picking a branch that has no worktree creates one under
`<workspace>.worktrees/`, picking one that already has a worktree reuses it,
and the pane starts there. A branch already checked out somewhere is never
given a second worktree, and a directory git already knows about is never
overwritten.

That binding is also the fix for the case that made this necessary: an agent
that creates a branch from inside a pane used to move every tab of the
workspace with it, because the cwd change was written onto the workspace. It
is now applied to the tab that caused it, and the sibling tabs keep the
branch they were working on.

The binding is persisted per tab (`TabSession.worktree`, additive and
defaulted, no schema version bump), and the git probes follow it: a bound
worktree gets its own branch and diffstat, deduplicated so two tabs on one
checkout still cost a single subprocess per tick.

## The rail header becomes a Customize Sidebar menu

The density switch #46 proposed lands as a menu rather than as a pair of
Appearance tiles, next to the rail it changes. Its "Show" submenu holds four
switches, all off by default, so the rail keeps today's look until something
is turned on:

- **Branch** - the tab's checkout on a second line, at the same size as the
  tab name rather than at caption size: with worktrees bound per tab, the
  branch is what tells two tabs of one project apart, so it reads as a value.
- **PR** - replaces the branch glyph with a pull-request glyph in GitHub's own
  state colors (open green, draft grey, merged purple, closed red), read
  through `gh` off the render thread and cached per repository and branch. No
  PR, no marker: the switch turns on the lookup, not the icon.
- **Diffstat** - insertions and deletions pinned right, drawn only when the
  checkout has something to report.
- **Indent guide** - the hairline under the workspace folder icon, broken
  around a running agent's badge so the line never crosses the spinner.

Below "Show", separated by a divider, an **Expand all / Collapse all** entry
that holds the menu open, and the fold state of each workspace row now
survives a restart (`WorkspaceSession.sidebar_collapsed`, additive and
defaulted): closing ten folders and reopening two was a chore that had to be
redone at every launch.

## What it looks like

<img width="781" height="686" alt="The Customize Sidebar menu, with Branch, Diffstat, PR and Indent guide on" src="https://github.com/user-attachments/assets/a5f91385-a5da-4aeb-b94a-b783bfcba591" />

## Validation

- `cargo fmt --check` - clean, on both commits
- `cargo clippy --workspace --all-targets --locked -- -D warnings` - 0, on
  both commits
- `cargo test --workspace --locked` - green (2290 tests)
- Linux x86_64 (Fedora, Wayland). The touched code carries no per-platform
  `#[cfg]` branch and goes through `PathBuf` and `which`, but macOS and
  Windows were not exercised on hardware.
