### PR TITLE
feat(sidebar): point the cursor on the rail's clickable rows

### DIFF
--- a/src-app/src/app/sidebar/mod.rs
+++ b/src-app/src/app/sidebar/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod context_menu;
 
 use crate::ui_primitives::TooltipDelayExt;
 use gpui::{
-    Animation, AnimationExt, AnyElement, AppContext, ClickEvent, Context, FontWeight,
+    Animation, AnimationExt, AnyElement, AppContext, ClickEvent, Context, CursorStyle, FontWeight,
     InteractiveElement, IntoElement, KeyDownEvent, MouseButton, ParentElement, Render,
     SharedString, Styled, Window, div, prelude::*, px, rgb, svg,
 };
@@ -285,6 +285,7 @@ fn sidebar_action_button(
     let active_bg = crate::app::constants::sidebar_tab_active_background();
     div()
         .id(id)
+        .cursor(CursorStyle::PointingHand)
         .flex_none()
         .size(px(SIDEBAR_ACTION_BUTTON_SIZE))
         .flex()
@@ -573,6 +574,9 @@ impl PaneFlowApp {
             .bg(ui.overlay)
             .px_1()
             .rounded_sm()
+            // The row underneath now asks for a pointing hand; a field being
+            // typed into must not inherit it.
+            .cursor(CursorStyle::IBeam)
             .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
             .on_mouse_down(MouseButton::Right, |_, _, cx| cx.stop_propagation())
             .child(self.rename_input.clone())
@@ -956,6 +960,13 @@ impl PaneFlowApp {
         let is_expanded = ws.sidebar_expanded;
 
         let row_shell = sidebar_row_shell()
+            // Every row in the rail is a click target - selecting a tab,
+            // opening or folding a workspace - so the pointer says so, the way
+            // the app's other rows already do (`pane_palette`,
+            // `surface_picker`). Set here and not on `sidebar_row_shell`:
+            // `.cursor()` asks GPUI for the view being rendered, and the layout
+            // tests measure a bare shell outside one.
+            .cursor(CursorStyle::PointingHand)
             .id(SharedString::from(format!("ws-{ws_id}")))
             .group(group_name.clone())
             .on_drag(
@@ -1370,6 +1381,13 @@ impl PaneFlowApp {
         );
 
         let row_shell = sidebar_row_shell()
+            // Every row in the rail is a click target - selecting a tab,
+            // opening or folding a workspace - so the pointer says so, the way
+            // the app's other rows already do (`pane_palette`,
+            // `surface_picker`). Set here and not on `sidebar_row_shell`:
+            // `.cursor()` asks GPUI for the view being rendered, and the layout
+            // tests measure a bare shell outside one.
+            .cursor(CursorStyle::PointingHand)
             .id(SharedString::from(format!("tab-row-{tab_id}")))
             .group(tab_group.clone())
             .on_drag(


### PR DESCRIPTION
The one standalone piece of #46 that does not depend on its rail redesign, kept
under its author's name.

The rail was the last list of clickable rows in the app still showing the arrow
cursor: `pane_palette` and `surface_picker` had already moved to a pointing
hand. Workspace rows, tab rows and the row action button now do the same, and
the rename field asks for an I-beam so a field being typed into does not
inherit the hand from the row under it.

## Validation

- `cargo fmt --check` - clean
- `cargo clippy -p paneflow-app --all-targets --locked -- -D warnings` - 0
- Linux x86_64 (Fedora, Wayland). No per-platform branch touched.

Refs #46