### PR TITLE
ci(libghostty): automate the pinned source bump

### DIFF
--- a/.github/actions/libghostty-windows-toolchain/action.yml
+++ b/.github/actions/libghostty-windows-toolchain/action.yml
@@ -1,0 +1,131 @@
+name: libghostty Windows toolchain
+description: >-
+  Installs the manifest-pinned Zig distribution, MSVC toolset, Windows SDK, and
+  LLVM normalization tools that the Windows libghostty recipe requires. Reads
+  every pin from native/libghostty/manifest.toml in the checked-out workspace,
+  so a staged bump manifest is honored without passing versions separately.
+
+outputs:
+  zig:
+    description: Absolute path to the pinned zig.exe
+    value: ${{ steps.zig.outputs.zig }}
+  zig-source-archive:
+    description: Absolute path to the pinned Zig source archive
+    value: ${{ steps.zig.outputs.source-archive }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install manifest-pinned Zig distribution
+      id: zig
+      shell: pwsh
+      run: |
+        $ManifestPath = Join-Path $PWD 'native\libghostty\manifest.toml'
+        . (Join-Path $PWD 'scripts\libghostty-manifest.ps1')
+
+        $zigVersion = Get-ManifestString 'zig_version'
+        $archiveUrl = Get-ManifestString 'windows_zig_archive_url'
+        $expectedArchiveSha = Get-ManifestString 'windows_zig_archive_sha256'
+        $sourceArchiveUrl = Get-ManifestString 'windows_zig_source_archive_url'
+        $expectedSourceArchiveSha = Get-ManifestString 'windows_zig_source_archive_sha256'
+        $toolRoot = Join-Path $env:RUNNER_TEMP "paneflow-zig-$zigVersion"
+        $archive = "$toolRoot.zip"
+        $sourceArchive = "$toolRoot-source.tar.xz"
+        if ((Test-Path -LiteralPath $toolRoot) -or
+            (Test-Path -LiteralPath $archive) -or
+            (Test-Path -LiteralPath $sourceArchive)) {
+          throw "refusing to replace an existing Zig tool path: $toolRoot"
+        }
+        Invoke-WebRequest -Uri $archiveUrl -OutFile $archive
+        $actualArchiveSha = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($actualArchiveSha -ne $expectedArchiveSha) {
+          throw "Zig distribution checksum mismatch: expected $expectedArchiveSha, got $actualArchiveSha"
+        }
+        Expand-Archive -LiteralPath $archive -DestinationPath $toolRoot
+        $zig = Join-Path $toolRoot "zig-x86_64-windows-$zigVersion\zig.exe"
+        if (-not (Test-Path -LiteralPath $zig -PathType Leaf)) {
+          throw "Zig distribution did not contain the expected executable: $zig"
+        }
+        Invoke-WebRequest -Uri $sourceArchiveUrl -OutFile $sourceArchive
+        $actualSourceArchiveSha = (Get-FileHash -LiteralPath $sourceArchive -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($actualSourceArchiveSha -ne $expectedSourceArchiveSha) {
+          throw "Zig source archive checksum mismatch: expected $expectedSourceArchiveSha, got $actualSourceArchiveSha"
+        }
+        "zig=$zig" | Out-File -LiteralPath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        "source-archive=$sourceArchive" | Out-File -LiteralPath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+    - name: Install manifest-pinned MSVC toolset and Windows SDK
+      shell: pwsh
+      env:
+        MSVC_COMPONENT: Microsoft.VisualStudio.Component.VC.14.38.17.8.x86.x64
+        WINDOWS_SDK_COMPONENT: Microsoft.VisualStudio.Component.Windows11SDK.26100
+        LLVM_COMPONENT: Microsoft.VisualStudio.Component.VC.Llvm.Clang
+      run: |
+        $ManifestPath = Join-Path $PWD 'native\libghostty\manifest.toml'
+        . (Join-Path $PWD 'scripts\libghostty-manifest.ps1')
+
+        $installerRoot = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer'
+        $vswhere = Join-Path $installerRoot 'vswhere.exe'
+        $setup = Join-Path $installerRoot 'setup.exe'
+        $installationPath = (& $vswhere -latest -products * -property installationPath | Select-Object -First 1)
+        if ([string]::IsNullOrWhiteSpace($installationPath)) {
+          throw 'Visual Studio 2022 is not installed on the runner.'
+        }
+
+        $requiredComponents = @($env:MSVC_COMPONENT, $env:WINDOWS_SDK_COMPONENT, $env:LLVM_COMPONENT)
+        $missingComponents = @(
+          foreach ($component in $requiredComponents) {
+            $installedAt = (& $vswhere -latest -products * -requires $component -property installationPath | Select-Object -First 1)
+            if ([string]::IsNullOrWhiteSpace($installedAt)) {
+              $component
+            }
+          }
+        )
+
+        if ($missingComponents.Count -gt 0) {
+          if (-not (Test-Path -LiteralPath $setup -PathType Leaf)) {
+            throw "Visual Studio Installer was not found at $setup."
+          }
+
+          $arguments = @(
+            'modify',
+            '--installPath', "`"$installationPath`"",
+            '--quiet',
+            '--norestart'
+          )
+          foreach ($component in $missingComponents) {
+            $arguments += @('--add', $component)
+          }
+
+          Write-Host "Installing Visual Studio components: $($missingComponents -join ', ')"
+          $process = Start-Process -FilePath $setup -ArgumentList $arguments -Wait -PassThru
+          if ($process.ExitCode -notin @(0, 3010)) {
+            throw "Visual Studio Installer exited with code $($process.ExitCode)."
+          }
+        }
+
+        $msvcToolset = Get-ManifestString 'windows_msvc_toolset'
+        $windowsSdk = Get-ManifestString 'windows_sdk'
+        $msvcPath = Join-Path $installationPath "VC\Tools\MSVC\$msvcToolset"
+        $sdkPath = Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\Lib\$windowsSdk"
+        if (-not (Test-Path -LiteralPath $msvcPath -PathType Container)) {
+          throw "The manifest-pinned MSVC toolset was not found at $msvcPath."
+        }
+        if (-not (Test-Path -LiteralPath $sdkPath -PathType Container)) {
+          throw "The manifest-pinned Windows SDK was not found at $sdkPath."
+        }
+
+        # The archive normalization recipe is LLVM-version-sensitive, and the
+        # build script hard-fails on any other version. Surface that as a
+        # labelled preflight failure rather than an opaque llvm-objcopy error
+        # 40 minutes into the rebuild.
+        $expectedLlvm = Get-ManifestString 'windows_llvm_version'
+        $llvmObjcopy = Join-Path $installationPath 'VC\Tools\Llvm\x64\bin\llvm-objcopy.exe'
+        if (-not (Test-Path -LiteralPath $llvmObjcopy -PathType Leaf)) {
+          throw "The LLVM normalization tools were not found at $llvmObjcopy."
+        }
+        $llvmVersion = @(& $llvmObjcopy --version)
+        if ($LASTEXITCODE -ne 0 -or -not ($llvmVersion -match "LLVM version $([regex]::Escape($expectedLlvm))")) {
+          throw "libghostty requires LLVM normalization tools $expectedLlvm; this runner carries: $($llvmVersion -join ' ')"
+        }
+        Write-Host "LLVM normalization tools: $expectedLlvm at $llvmObjcopy"

--- a/.github/workflows/libghostty-bump.yml
+++ b/.github/workflows/libghostty-bump.yml
@@ -1,0 +1,561 @@
+name: libghostty bump
+
+# Re-pins native/libghostty/manifest.toml onto a newer Ghostty commit and opens
+# a pull request carrying the four rebuilt archives.
+#
+# The build recipes read source_sha, header_sha256, bindings_sha256, and their
+# own archive hashes from the manifest and refuse to run against a checkout that
+# does not match, so the order here is fixed: stage the manifest, regenerate the
+# bindings, then build every target against the staged manifest with
+# --allow-hash-drift, and only then write the hashes the builds produced.
+#
+# Nothing here merges. The pull request goes through the ordinary
+# libghostty-{linux,macos,windows} gates, and those runs start in an
+# approval-required state because a GITHUB_TOKEN opened the pull request.
+# Reproducibility is proven here rather than there: a pull request lane only
+# checks the committed archive against the manifest hash, which a bump commit
+# writes itself, so a bump that did not prove itself would be circular.
+
+on:
+  schedule:
+    # Weekly rather than nightly: at Ghostty's merge rate this picks up the same
+    # commits with a fraction of the review load.
+    - cron: "23 4 * * 1"
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: "Ghostty commit to pin (default: upstream main HEAD)"
+        required: false
+        type: string
+      dry_run:
+        description: "Build and verify without opening a pull request"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: libghostty-bump
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  GHOSTTY_REPOSITORY: ghostty-org/ghostty
+
+jobs:
+  resolve:
+    name: Resolve target commit and stage the manifest
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    outputs:
+      needed: ${{ steps.target.outputs.needed }}
+      source_sha: ${{ steps.target.outputs.source_sha }}
+      short_sha: ${{ steps.target.outputs.short_sha }}
+      current_sha: ${{ steps.target.outputs.current_sha }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Resolve the target Ghostty commit
+        id: target
+        env:
+          REQUESTED_SHA: ${{ inputs.source_sha }}
+        run: |
+          manifest_string() {
+            sed -n "s/^$1 = \"\(.*\)\"$/\1/p" native/libghostty/manifest.toml
+          }
+          current="$(manifest_string source_sha)"
+          if [ -n "$REQUESTED_SHA" ]; then
+            case "$REQUESTED_SHA" in
+              *[!0-9a-f]*) echo "::error::source_sha must be a full lowercase hex commit id"; exit 1 ;;
+            esac
+            target="$REQUESTED_SHA"
+          else
+            target="$(git ls-remote "https://github.com/${GHOSTTY_REPOSITORY}.git" HEAD | cut -f1)"
+          fi
+          if [ "${#target}" -ne 40 ]; then
+            echo "::error::could not resolve a full Ghostty commit id (got '$target')"
+            exit 1
+          fi
+          {
+            echo "current_sha=$current"
+            echo "source_sha=$target"
+            echo "short_sha=$(printf '%s' "$target" | cut -c1-8)"
+          } >> "$GITHUB_OUTPUT"
+          if [ "$current" = "$target" ]; then
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            echo "already pinned to $target"
+          else
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+            echo "bumping $current -> $target"
+          fi
+
+      - name: Checkout the target Ghostty source
+        if: steps.target.outputs.needed == 'true'
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          repository: ghostty-org/ghostty
+          ref: ${{ steps.target.outputs.source_sha }}
+          path: .ghostty-source
+          fetch-depth: 1
+          persist-credentials: false
+
+      # Both preflights below cost seconds and guard hours. A Zig bump needs new
+      # distribution URLs and checksums, and a moved formatter.zig needs the
+      # Windows patch rebased by hand. Neither is something this workflow may
+      # decide on its own, and neither should surface as a Windows job failing
+      # forty minutes in.
+      - name: Preflight the pins this workflow cannot move
+        if: steps.target.outputs.needed == 'true'
+        env:
+          SOURCE_DIR: ${{ github.workspace }}/.ghostty-source
+        run: |
+          manifest_string() {
+            sed -n "s/^$1 = \"\(.*\)\"$/\1/p" native/libghostty/manifest.toml
+          }
+          normalized_sha256() {
+            perl -0pe 's/\r\n/\n/g; s/\r/\n/g' "$1" | sha256sum | awk '{print $1}'
+          }
+
+          pinned_zig="$(manifest_string zig_version)"
+          upstream_zig="$(
+            sed -nE 's/^[[:space:]]*\.minimum_zig_version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' \
+              "$SOURCE_DIR/build.zig.zon" | head -1
+          )"
+          if [ -z "$upstream_zig" ]; then
+            echo "::error::could not read minimum_zig_version from the target build.zig.zon"
+            exit 1
+          fi
+          if [ "$pinned_zig" != "$upstream_zig" ]; then
+            echo "::error::this commit needs Zig $upstream_zig but the manifest pins $pinned_zig. A Zig bump also moves windows_zig_archive_url, its checksums, windows_zig_image_base, and windows_zig_dll_characteristics, so re-pin Zig by hand first."
+            exit 1
+          fi
+
+          patch_target="$(manifest_string windows_source_patch_target)"
+          expected_input="$(manifest_string windows_source_patch_input_sha256)"
+          actual_input="$(normalized_sha256 "$SOURCE_DIR/$patch_target")"
+          if [ "$actual_input" != "$expected_input" ]; then
+            echo "::error::$patch_target moved upstream, so native/libghostty/patches/windows-formatter-determinism.patch no longer applies to it. Rebase the patch, then re-pin windows_source_patch_sha256, windows_source_patch_input_sha256, and windows_source_patch_output_sha256 by hand."
+            exit 1
+          fi
+          echo "Zig $pinned_zig and the Windows formatter patch both still apply"
+
+      - name: Stage the manifest onto the target commit
+        if: steps.target.outputs.needed == 'true'
+        env:
+          SOURCE_DIR: ${{ github.workspace }}/.ghostty-source
+          SOURCE_SHA: ${{ steps.target.outputs.source_sha }}
+          SHORT_SHA: ${{ steps.target.outputs.short_sha }}
+        run: |
+          manifest_string() {
+            sed -n "s/^$1 = \"\(.*\)\"$/\1/p" native/libghostty/manifest.toml
+          }
+
+          header_path="$(manifest_string header_path)"
+          header_sha="$(sha256sum "$SOURCE_DIR/$header_path" | awk '{print $1}')"
+          epoch="$(git -C "$SOURCE_DIR" show -s --format=%ct HEAD)"
+          app_version="$(
+            sed -nE 's/^[[:space:]]*\.version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' \
+              "$SOURCE_DIR/build.zig.zon" | head -1
+          )"
+          if [ -z "$app_version" ]; then
+            echo "::error::could not read .version from the target build.zig.zon"
+            exit 1
+          fi
+
+          # The canonical build roots carry the short commit id, and their
+          # *length* is part of the macOS recipe: debug sections embed absolute
+          # paths, and llvm-strip leaves a hole whose size follows that length.
+          # A same-width short id keeps the recipe intact.
+          old_short="$(manifest_string source_sha | cut -c1-8)"
+          macos_root="$(manifest_string macos_canonical_source_path)"
+          windows_root="$(manifest_string windows_canonical_source_path)"
+          api_version="$(manifest_string api_version)"
+          short_app_sha="$(printf '%s' "$SOURCE_SHA" | cut -c1-9)"
+
+          scripts/repin-libghostty-manifest.sh \
+            --set "source_sha=$SOURCE_SHA" \
+            --set "ghostty_app_version=${app_version}+${short_app_sha}" \
+            --set "header_sha256=$header_sha" \
+            --set "windows_source_date_epoch=$epoch" \
+            --set "macos_canonical_source_path=${macos_root%$old_short}$SHORT_SHA" \
+            --set "windows_canonical_source_path=${windows_root%$old_short}$SHORT_SHA" \
+            --set-license "libghostty-vt:version=${api_version}-dev@$SOURCE_SHA"
+
+          git --no-pager diff -- native/libghostty/manifest.toml
+
+      - name: Upload the staged manifest
+        if: steps.target.outputs.needed == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: libghostty-bump-manifest
+          path: native/libghostty/manifest.toml
+          retention-days: 5
+          if-no-files-found: error
+
+  bindings:
+    name: Regenerate bindings
+    needs: resolve
+    if: needs.resolve.outputs.needed == 'true'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: libghostty-bump-manifest
+          path: native/libghostty
+
+      - name: Checkout the target Ghostty source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          repository: ghostty-org/ghostty
+          ref: ${{ needs.resolve.outputs.source_sha }}
+          path: .ghostty-source
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
+        with:
+          toolchain: "1.98.0"
+          components: rustfmt
+
+      - name: Install pinned bindgen
+        run: cargo install bindgen-cli --version 0.72.1 --locked
+
+      - name: Regenerate bindings from the target header
+        env:
+          PANEFLOW_GHOSTTY_SOURCE_DIR: ${{ github.workspace }}/.ghostty-source
+        run: |
+          output="$(scripts/generate-libghostty-bindings.sh --write)"
+          printf '%s\n' "$output"
+          sha="$(printf '%s\n' "$output" | sed -n 's/^bindings_sha256=//p')"
+          if [ -z "$sha" ]; then
+            echo "::error::the bindings generator did not report a hash"
+            exit 1
+          fi
+          scripts/repin-libghostty-manifest.sh --set "bindings_sha256=$sha"
+
+      - name: Upload the staged manifest and bindings
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: libghostty-bump-staged
+          path: |
+            native/libghostty/manifest.toml
+            native/libghostty/bindings.rs
+          retention-days: 5
+          if-no-files-found: error
+
+  linux:
+    name: Rebuild ${{ matrix.target }}
+    needs: [resolve, bindings]
+    runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runs-on: ubuntu-22.04
+          - target: aarch64-unknown-linux-gnu
+            runs-on: ubuntu-22.04-arm
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: libghostty-bump-staged
+          path: native/libghostty
+
+      - name: Checkout the target Ghostty source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          repository: ghostty-org/ghostty
+          ref: ${{ needs.resolve.outputs.source_sha }}
+          path: .ghostty-source
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        with:
+          version: "0.16.0"
+
+      - uses: ./.github/actions/linux-build-deps
+        with:
+          extra-packages: binutils elfutils
+
+      - name: Build and prove reproducibility
+        env:
+          PANEFLOW_GHOSTTY_SOURCE_DIR: ${{ github.workspace }}/.ghostty-source
+        run: |
+          scripts/ci-retry-network.sh \
+            scripts/build-libghostty-linux.sh \
+            --target "${{ matrix.target }}" \
+            --verify-reproducible \
+            --allow-hash-drift
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: libghostty-bump-${{ matrix.target }}
+          path: target/libghostty/${{ matrix.target }}
+          retention-days: 5
+          if-no-files-found: error
+
+  macos:
+    name: Rebuild aarch64-apple-darwin
+    needs: [resolve, bindings]
+    # Cross-built on Linux on purpose: Ghostty only takes the Apple libtool
+    # combine path when the build host is Darwin, and the reviewed recipe
+    # normalizes the zig ar -M combine that a Linux host keeps.
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: libghostty-bump-staged
+          path: native/libghostty
+
+      - name: Checkout the target Ghostty source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          repository: ghostty-org/ghostty
+          ref: ${{ needs.resolve.outputs.source_sha }}
+          path: .ghostty-source
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        with:
+          version: "0.16.0"
+
+      # llvm-strip and llvm-ar come from the repository's own pinned Rust
+      # toolchain, so macos_llvm_version moves only when that toolchain moves.
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
+        with:
+          toolchain: "1.98.0"
+          components: llvm-tools
+
+      - name: Build and prove reproducibility
+        env:
+          PANEFLOW_GHOSTTY_SOURCE_DIR: ${{ github.workspace }}/.ghostty-source
+        run: |
+          scripts/ci-retry-network.sh \
+            scripts/build-libghostty-macos.sh \
+            --verify-reproducible \
+            --allow-hash-drift
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: libghostty-bump-aarch64-apple-darwin
+          path: target/libghostty/aarch64-apple-darwin
+          retention-days: 5
+          if-no-files-found: error
+
+  windows:
+    name: Rebuild x86_64-pc-windows-msvc
+    needs: [resolve, bindings]
+    runs-on: windows-2022
+    timeout-minutes: 180
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: libghostty-bump-staged
+          path: native/libghostty
+
+      - name: Checkout the target Ghostty source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          repository: ghostty-org/ghostty
+          ref: ${{ needs.resolve.outputs.source_sha }}
+          path: .ghostty-source
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install the manifest-pinned Windows toolchain
+        id: toolchain
+        uses: ./.github/actions/libghostty-windows-toolchain
+
+      - name: Build and prove reproducibility
+        env:
+          PANEFLOW_GHOSTTY_SOURCE_DIR: ${{ github.workspace }}\.ghostty-source
+          EVIDENCE_DIR: ${{ runner.temp }}\libghostty-bump-evidence
+        run: |
+          & .\scripts\build-libghostty-windows.ps1 `
+            -Zig "${{ steps.toolchain.outputs.zig }}" `
+            -ZigSourceArchive "${{ steps.toolchain.outputs.zig-source-archive }}" `
+            -VerifyReproducible `
+            -AllowHashDrift
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: libghostty-bump-x86_64-pc-windows-msvc
+          path: target/libghostty/x86_64-pc-windows-msvc
+          retention-days: 5
+          if-no-files-found: error
+
+  assemble:
+    name: Re-pin the archives and open the pull request
+    needs: [resolve, bindings, linux, macos, windows]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: libghostty-bump-staged
+          path: native/libghostty
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: libghostty-bump-*
+          path: ${{ runner.temp }}/rebuilt
+
+      - name: Publish the rebuilt archives and re-pin their hashes
+        env:
+          REBUILT: ${{ runner.temp }}/rebuilt
+        run: |
+          for target in \
+            x86_64-unknown-linux-gnu \
+            aarch64-unknown-linux-gnu \
+            aarch64-apple-darwin \
+            x86_64-pc-windows-msvc
+          do
+            src="$REBUILT/libghostty-bump-$target"
+            dst="native/libghostty/prebuilt/$target"
+            if [ ! -d "$src" ]; then
+              echo "::error::missing rebuilt tree for $target"
+              exit 1
+            fi
+
+            rm -rf "$dst"
+            mkdir -p "$dst"
+            # Copy exactly what a reviewed prebuilt tree carries. build.zig.zon
+            # and the reproducibility evidence stay out of the repository.
+            for entry in bindings.rs build-info.txt headers.sha256 symbols.txt include lib; do
+              if [ -e "$src/$entry" ]; then
+                cp -r "$src/$entry" "$dst/$entry"
+              fi
+            done
+            if [ ! -d "$dst/lib" ]; then
+              echo "::error::$target produced no lib/ directory"
+              exit 1
+            fi
+
+            archive_path="$(
+              awk -v t="$target" '
+                $0 == "[targets.\"" t "\"]" { inside = 1; next }
+                inside && /^\[/ { exit }
+                inside && /^archive_path = "/ {
+                  sub(/^archive_path = "/, ""); sub(/"$/, ""); print; exit
+                }
+              ' native/libghostty/manifest.toml
+            )"
+            archive_sha="$(sha256sum "$dst/$archive_path" | awk '{print $1}')"
+            scripts/repin-libghostty-manifest.sh \
+              --set-target "$target:archive_sha256=$archive_sha"
+
+            if [ "$target" = "x86_64-pc-windows-msvc" ]; then
+              scripts/repin-libghostty-manifest.sh \
+                --set-target "$target:build_info_sha256=$(sha256sum "$dst/build-info.txt" | awk '{print $1}')" \
+                --set-target "$target:headers_index_sha256=$(sha256sum "$dst/headers.sha256" | awk '{print $1}')" \
+                --set-target "$target:symbols_sha256=$(sha256sum "$dst/symbols.txt" | awk '{print $1}')"
+            fi
+            echo "$target: $archive_sha"
+          done
+
+      # The consumer crate re-derives every hash it links against, so building
+      # it here is the cheapest end-to-end check that the re-pinned manifest and
+      # the published trees agree before a human is asked to look.
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
+        with:
+          toolchain: "1.98.0"
+
+      - name: Verify the re-pinned repository artifact
+        run: cargo build -p paneflow-libghostty-sys --locked
+
+      - name: Open the pull request
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+          SHORT_SHA: ${{ needs.resolve.outputs.short_sha }}
+          CURRENT_SHA: ${{ needs.resolve.outputs.current_sha }}
+        run: |
+          branch="bot/libghostty-$SHORT_SHA"
+          # Never overwrite an existing bump branch. A human rebasing the
+          # Windows patch or fixing a binding break works on exactly this
+          # branch, and a re-run must not throw that away.
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            echo "::error::$branch already exists. Delete it, or finish the bump that is already open."
+            exit 1
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add native/libghostty
+          if git diff --cached --quiet; then
+            echo "::error::the bump produced no change to commit"
+            exit 1
+          fi
+          git commit -m "chore(libghostty): re-pin libghostty-vt to $SHORT_SHA"
+          git push origin "$branch"
+
+          {
+            echo "Re-pins libghostty-vt from \`$CURRENT_SHA\` to \`$SOURCE_SHA\`."
+            echo
+            echo "Upstream range: https://github.com/${GHOSTTY_REPOSITORY}/compare/${CURRENT_SHA}...${SOURCE_SHA}"
+            echo
+            echo "Every archive here was rebuilt from the pinned source and proven"
+            echo "reproducible in the run that opened this pull request, on all four"
+            echo "reviewed targets. The libghostty lanes below only check a committed"
+            echo "archive against its manifest hash, and a bump commit writes that hash"
+            echo "itself, so this run is the reproducibility evidence."
+            echo
+            echo "Before merging:"
+            echo
+            echo "- Approve the workflow runs on this pull request. They start held"
+            echo "  because a \`GITHUB_TOKEN\` opened it."
+            echo "- Read the upstream range for VT behavior changes. Green gates prove"
+            echo "  the build, the static link, and archive integrity. They do not prove"
+            echo "  the rendering."
+            echo "- Run Paneflow once on this branch."
+          } > "$RUNNER_TEMP/pr-body.md"
+
+          gh pr create \
+            --title "chore(libghostty): re-pin libghostty-vt to $SHORT_SHA" \
+            --body-file "$RUNNER_TEMP/pr-body.md" \
+            --base main \
+            --head "$branch"
+
+      - name: Report the dry run
+        if: ${{ inputs.dry_run }}
+        run: |
+          {
+            echo "### libghostty bump dry run"
+            echo
+            echo "Target commit \`${{ needs.resolve.outputs.source_sha }}\` built and verified on every target. No pull request was opened."
+          } >> "$GITHUB_STEP_SUMMARY"
+          git --no-pager diff --stat

--- a/native/libghostty/README.md
+++ b/native/libghostty/README.md
@@ -165,6 +165,36 @@ a rebuild. `paneflow-libghostty-sys/build.rs` selects this directory only for
 or incoherent metadata with an actionable rebuild command, and emits only
 static plus reviewed system link directives.
 
+## Bumping the pinned source
+
+`.github/workflows/libghostty-bump.yml` performs the re-pin. It runs weekly and
+on demand (`workflow_dispatch` accepts an explicit `source_sha`, and a `dry_run`
+input builds everything without opening a pull request). It stages the manifest
+onto the target commit, regenerates the bindings, rebuilds all four reviewed
+targets with `--verify-reproducible --allow-hash-drift`, writes the hashes those
+builds produced, and opens a pull request. Nothing merges on its own.
+
+Reproducibility is proven in the bump run itself, not on the resulting pull
+request: a pull request lane only checks a committed archive against its
+manifest hash, and a bump commit writes that hash, so the pull request alone
+would be circular evidence.
+
+Two pins the workflow deliberately refuses to move, both checked in seconds
+before any build starts:
+
+- **Zig.** A commit whose `minimum_zig_version` moved also needs a new
+  distribution URL, its checksums, `windows_zig_image_base`, and
+  `windows_zig_dll_characteristics`. Re-pin Zig by hand first.
+- **The Windows formatter patch.** `patches/windows-formatter-determinism.patch`
+  is pinned to the exact bytes of its target file. When upstream touches
+  `src/terminal/formatter.zig`, rebase the patch and re-pin
+  `windows_source_patch_sha256`, `windows_source_patch_input_sha256`, and
+  `windows_source_patch_output_sha256`.
+
+`scripts/repin-libghostty-manifest.sh` performs the manifest edits and is the
+supported way to re-pin a field by hand. Every edit requires the key to already
+exist, so a renamed field fails the bump instead of adding a dead entry.
+
 ## ABI and licensing
 
 `paneflow-libghostty-sys` is the only raw ABI surface. The safe wrapper owns

--- a/scripts/build-libghostty-windows.ps1
+++ b/scripts/build-libghostty-windows.ps1
@@ -5,7 +5,11 @@ param(
     [string]$Zig = "zig",
     [string]$ZigSourceArchive = $env:PANEFLOW_ZIG_SOURCE_ARCHIVE,
     [string]$EvidenceDir = $env:EVIDENCE_DIR,
-    [switch]$VerifyReproducible
+    [switch]$VerifyReproducible,
+    # Only for minting a new reviewed archive: it downgrades the manifest hash
+    # gates to warnings so the recipe can be re-pinned deliberately. Matches
+    # scripts/build-libghostty-linux.sh and scripts/build-libghostty-macos.sh.
+    [switch]$AllowHashDrift
 )
 
 Set-StrictMode -Version Latest
@@ -1115,7 +1119,13 @@ try {
 
     $actualArchiveSha = Get-Sha256 (Join-Path $first $ArchivePath)
     if ($actualArchiveSha -ne $ExpectedArchiveSha) {
-        throw "canonical Windows archive hash differs from manifest; expected $ExpectedArchiveSha, got $actualArchiveSha"
+        $message = "canonical Windows archive hash differs from manifest; expected $ExpectedArchiveSha, got $actualArchiveSha"
+        if ($AllowHashDrift) {
+            Write-Warning $message
+        }
+        else {
+            throw $message
+        }
     }
     foreach ($metadata in @(
         @{ Path = "build-info.txt"; Expected = $ExpectedBuildInfoSha },
@@ -1125,7 +1135,13 @@ try {
         $metadataPath = Join-Path $first $metadata.Path
         $metadataSha = Get-Sha256 $metadataPath
         if ($metadataSha -ne $metadata.Expected) {
-            throw "canonical Windows metadata hash differs for $($metadata.Path); expected $($metadata.Expected), got $metadataSha"
+            $message = "canonical Windows metadata hash differs for $($metadata.Path); expected $($metadata.Expected), got $metadataSha"
+            if ($AllowHashDrift) {
+                Write-Warning $message
+            }
+            else {
+                throw $message
+            }
         }
     }
 

--- a/scripts/generate-libghostty-bindings.sh
+++ b/scripts/generate-libghostty-bindings.sh
@@ -5,6 +5,22 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 MANIFEST="$ROOT/native/libghostty/manifest.toml"
 SOURCE_DIR="${PANEFLOW_GHOSTTY_SOURCE_DIR:-}"
 BINDGEN_VERSION="0.72.1"
+WRITE=0
+
+while (($#)); do
+  case "$1" in
+    --write)
+      # Only for a deliberate bump: the default mode is a gate that fails on
+      # any drift, which is what every workflow but the bump wants.
+      WRITE=1
+      shift
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
 
 manifest_string() {
   sed -n "s/^$1 = \"\(.*\)\"$/\1/p" "$MANIFEST"
@@ -81,9 +97,21 @@ sed -i 's/::core::ffi::/core::ffi::/g' "$OUTPUT"
 sed -i 's/^pub type \(Ghostty[A-Za-z0-9_]*\) = core::ffi::c_uint;$/pub type \1 = core::ffi::c_int;/' "$OUTPUT"
 rustfmt --edition 2024 "$OUTPUT"
 
-if ! cmp -s "$OUTPUT" "$ROOT/$(manifest_string bindings_path)"; then
-  diff -u "$ROOT/$(manifest_string bindings_path)" "$OUTPUT" || true
+BINDINGS="$ROOT/$(manifest_string bindings_path)"
+if ! cmp -s "$OUTPUT" "$BINDINGS"; then
+  diff -u "$BINDINGS" "$OUTPUT" || true
+  if ((WRITE)); then
+    cat "$OUTPUT" > "$BINDINGS"
+    echo "libghostty bindings regenerated from the pinned header with bindgen $BINDGEN_VERSION"
+    echo "bindings_sha256=$(sha256sum "$BINDINGS" | awk '{print $1}')"
+    exit 0
+  fi
   echo "libghostty bindings differ from the pinned header; review and commit the regeneration" >&2
   exit 1
 fi
 echo "libghostty bindings match the pinned header and bindgen $BINDGEN_VERSION"
+if ((WRITE)); then
+  # A bump that lands on an unchanged header still has to re-pin the manifest,
+  # so emit the hash on both paths rather than only after a rewrite.
+  echo "bindings_sha256=$(sha256sum "$BINDINGS" | awk '{print $1}')"
+fi

--- a/scripts/repin-libghostty-manifest.sh
+++ b/scripts/repin-libghostty-manifest.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Re-pins native/libghostty/manifest.toml for a deliberate libghostty-vt bump.
+#
+# Every build recipe reads source_sha, header_sha256, bindings_sha256, and its
+# own archive hashes from the manifest, and refuses to run against a checkout
+# that does not match. A bump therefore has to stage the manifest before it can
+# build anything, which is all this script does: it never fetches Ghostty, never
+# runs Zig, and never touches an artifact.
+#
+# Each edit requires the key to already exist with a string value. A missing or
+# ambiguous key is an error, so a renamed manifest field fails the bump instead
+# of silently adding a dead entry.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+MANIFEST="$ROOT/native/libghostty/manifest.toml"
+EDITS=()
+
+usage() {
+  cat <<'USAGE'
+Usage: repin-libghostty-manifest.sh [options]
+
+  --set <key>=<value>                       re-pin a preamble key
+  --set-target <target>:<key>=<value>       re-pin a key inside [targets."<target>"]
+  --set-license <component>:<key>=<value>   re-pin a key inside a [[licenses]] entry
+  --manifest <path>                         operate on another manifest copy
+
+Values are written verbatim between the existing quotes, so they must not
+contain a double quote or a newline.
+USAGE
+}
+
+while (($#)); do
+  case "$1" in
+    --set|--set-target|--set-license)
+      [[ $# -ge 2 ]] || { echo "$1 requires an argument" >&2; exit 2; }
+      EDITS+=("${1#--set}|$2")
+      shift 2
+      ;;
+    --manifest)
+      [[ $# -ge 2 ]] || { echo "--manifest requires a path" >&2; exit 2; }
+      MANIFEST="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+[[ -f "$MANIFEST" ]] || { echo "manifest not found: $MANIFEST" >&2; exit 1; }
+((${#EDITS[@]})) || { echo "no edit requested" >&2; usage >&2; exit 2; }
+
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+apply_edit() {
+  local scope="$1" selector="$2" key="$3" value="$4"
+
+  case "$value" in
+    *\"*|*$'\n'*)
+      echo "value for $key must not contain a quote or a newline" >&2
+      return 1
+      ;;
+  esac
+
+  awk -v scope="$scope" -v selector="$selector" -v key="$key" -v value="$value" '
+    function flush_block(  i, line, replaced_here) {
+      if (block_component == selector) {
+        for (i = 1; i <= block_len; i++) {
+          line = block[i]
+          if (index(line, prefix) == 1 && substr(line, length(line)) == "\"") {
+            block[i] = prefix value "\""
+            replaced++
+          }
+        }
+      }
+      for (i = 1; i <= block_len; i++) print block[i]
+      block_len = 0
+      block_component = ""
+    }
+    BEGIN {
+      prefix = key " = \""
+      component_prefix = "component = \""
+      in_scope = (scope == "preamble")
+      in_block = 0
+      block_len = 0
+    }
+    scope == "license" {
+      if ($0 == "[[licenses]]") {
+        if (in_block) flush_block()
+        in_block = 1
+        block_len = 1
+        block[1] = $0
+        next
+      }
+      if (in_block) {
+        if (index($0, component_prefix) == 1 && substr($0, length($0)) == "\"") {
+          block_component = substr($0, length(component_prefix) + 1, length($0) - length(component_prefix) - 1)
+        }
+        block[++block_len] = $0
+        next
+      }
+      print
+      next
+    }
+    {
+      if (substr($0, 1, 1) == "[") {
+        if (scope == "preamble") in_scope = 0
+        else in_scope = ($0 == "[targets.\"" selector "\"]")
+        print
+        next
+      }
+      if (in_scope && index($0, prefix) == 1 && substr($0, length($0)) == "\"") {
+        print prefix value "\""
+        replaced++
+        next
+      }
+      print
+    }
+    END {
+      if (scope == "license" && in_block) flush_block()
+      if (replaced != 1) {
+        printf("expected exactly one %s match for %s, found %d\n", scope, key, replaced + 0) > "/dev/stderr"
+        exit 1
+      }
+    }
+  ' "$MANIFEST" > "$TMP"
+
+  cat "$TMP" > "$MANIFEST"
+}
+
+for edit in "${EDITS[@]}"; do
+  kind="${edit%%|*}"
+  spec="${edit#*|}"
+  case "$kind" in
+    "")
+      key="${spec%%=*}"
+      [[ "$key" != "$spec" ]] || { echo "--set needs <key>=<value>: $spec" >&2; exit 2; }
+      apply_edit preamble "" "$key" "${spec#*=}"
+      ;;
+    -target|-license)
+      selector="${spec%%:*}"
+      [[ "$selector" != "$spec" ]] || { echo "--set$kind needs <selector>:<key>=<value>: $spec" >&2; exit 2; }
+      rest="${spec#*:}"
+      key="${rest%%=*}"
+      [[ "$key" != "$rest" ]] || { echo "--set$kind needs <selector>:<key>=<value>: $spec" >&2; exit 2; }
+      apply_edit "${kind#-}" "$selector" "$key" "${rest#*=}"
+      ;;
+    *)
+      echo "internal error: unknown edit kind $kind" >&2
+      exit 1
+      ;;
+  esac
+  echo "re-pinned ${spec%%=*}"
+done


### PR DESCRIPTION
Re-pinning libghostty-vt was a manual pass across two build hosts. This adds the
workflow that performs it and opens the pull request, so the pins move without a
local Linux and Windows machine.

## What this changes for you

`.github/workflows/libghostty-bump.yml` runs weekly and on demand.
`workflow_dispatch` takes an optional `source_sha` (defaults to upstream `main`
HEAD) and a `dry_run` input that builds and verifies everything without opening
a pull request. It covers all four reviewed targets: both Linux triples,
`aarch64-apple-darwin` cross-built on Linux, and `x86_64-pc-windows-msvc`.

Nothing merges on its own. The resulting pull request goes through the ordinary
`libghostty-{linux,macos,windows}` gates, which start held for approval because
a `GITHUB_TOKEN` opened it.

## Why the job order is what it is

The build recipes read `source_sha`, `header_sha256`, `bindings_sha256`, and
their own archive hashes from the manifest, and refuse to run against a checkout
that does not match. So a bump has to stage the manifest before it can build
anything: `resolve` stages it, `bindings` regenerates and re-pins, the three
build jobs run against the staged manifest with `--verify-reproducible
--allow-hash-drift`, and `assemble` writes the hashes those builds produced.

Reproducibility is proven in the bump run rather than on the resulting pull
request. A pull request lane only checks a committed archive against its
manifest hash, and a bump commit writes that hash itself, so the pull request
alone would be circular evidence.

## Two pins the workflow refuses to move

Both are checked in seconds, before any build starts, so neither surfaces as a
Windows job failing forty minutes in:

- A moved `minimum_zig_version` also needs a new Zig distribution URL, its
  checksums, `windows_zig_image_base`, and `windows_zig_dll_characteristics`.
- A moved `src/terminal/formatter.zig` needs
  `patches/windows-formatter-determinism.patch` rebased, along with its three
  manifest hashes.

Each failure names the exact fields to re-pin by hand.

## Supporting changes

- `scripts/repin-libghostty-manifest.sh` (new): scoped manifest edits that fail
  on a missing key, so a renamed field fails the bump instead of adding a dead
  entry.
- `scripts/generate-libghostty-bindings.sh`: adds `--write` next to the existing
  gate mode, which is unchanged and still what `libghostty-linux.yml` calls.
- `scripts/build-libghostty-windows.ps1`: adds `-AllowHashDrift`, matching the
  Linux and macOS recipes.
- `.github/actions/libghostty-windows-toolchain` (new): the pinned Zig, MSVC
  toolset, Windows SDK, and LLVM install, extracted so the bump does not
  duplicate it.

The three existing libghostty workflows are untouched.

## Validation

Run locally on Windows 11, against the repository at `f2d5758f`:

- `cargo fmt --check` passes. No Rust file is touched.
- `bash -n` on both shell scripts, and a PowerShell AST parse of
  `build-libghostty-windows.ps1`.
- `yaml.safe_load` on the new workflow and the new composite action.
- `repin-libghostty-manifest.sh` on all three edit modes; scope isolation
  (`--set archive_sha256` refuses to touch a target section); failure on a
  missing key, on an unknown target, and on a missing license component; the
  manifest left byte-identical after every failure.
- The full `resolve` staging sequence against a manifest copy: it produces
  exactly seven changed lines, with `ghostty_app_version` in the existing
  `<version>+<sha9>` shape and both canonical build roots re-pinned to a
  same-width short id, which the macOS recipe depends on.
- The `assemble` `archive_path` lookup for all four targets, checked against the
  files actually present under `prebuilt/`, and the per-target re-pin loop
  including the three Windows-only metadata hashes.
- `git diff` on the staged manifest shows three changed lines and no line-ending
  noise.

## Not verified

The workflow has never run. No build, no pull request, and neither
`generate-libghostty-bindings.sh --write` nor `-AllowHashDrift` has been
exercised against a real Ghostty checkout. First use should be a
`workflow_dispatch` with a real upstream SHA and `dry_run` enabled.
