### PR TITLE
fix(libghostty): derive the bump macOS lane's LLVM toolchain

### DIFF
--- a/.github/workflows/libghostty-bump.yml
+++ b/.github/workflows/libghostty-bump.yml
@@ -340,11 +340,27 @@ jobs:
         with:
           version: "0.16.0"
 
-      # llvm-strip and llvm-ar come from the repository's own pinned Rust
-      # toolchain, so macos_llvm_version moves only when that toolchain moves.
+      # llvm-strip and llvm-ar have to be exactly the ones that normalized the
+      # committed archive: the recipe is LLVM-version-sensitive and the build
+      # script refuses any other version. That toolchain is the one
+      # macos_llvm_version names, and it is deliberately NOT
+      # rust-toolchain.toml's channel, so derive it from the manifest rather
+      # than duplicate a pin that a workspace bump would silently invalidate.
+      - name: Resolve the toolchain macos_llvm_version names
+        id: llvm
+        run: |
+          llvm="$(sed -n 's/^macos_llvm_version = "\(.*\)"$/\1/p' native/libghostty/manifest.toml)"
+          rust="$(printf '%s' "$llvm" | sed -n 's/^.*-rust-\(.*\)-stable$/\1/p')"
+          if [ -z "$rust" ]; then
+            echo "::error::could not read a Rust toolchain out of macos_llvm_version '$llvm'"
+            exit 1
+          fi
+          echo "rust=$rust" >> "$GITHUB_OUTPUT"
+          echo "macos_llvm_version $llvm needs Rust $rust"
+
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
         with:
-          toolchain: "1.98.0"
+          toolchain: ${{ steps.llvm.outputs.rust }}
           components: llvm-tools
 
       - name: Build and prove reproducibility


### PR DESCRIPTION
First dry run of the bump workflow ([run 33525510452](https://github.com/arthjean/paneflow/actions/runs/33525510452)) failed the macOS lane in 39 seconds:

```
libghostty requires LLVM 22.1.2-rust-1.96.1-stable for .../1.98.0-x86_64-unknown-linux-gnu/.../llvm-strip
  LLVM version 22.1.8-rust-1.98.0-stable
```

The job installed Rust 1.98.0, the workspace channel. The macOS recipe needs the llvm-tools that normalized the committed archive, which `macos_llvm_version` names and which is deliberately not `rust-toolchain.toml`'s channel.

Rather than write a second copy of the pin, the lane now reads the Rust version out of `macos_llvm_version`. The duplicated pin is what caused this failure, and a workspace toolchain bump would have caused it again.

## Validation

- The extraction reproduced locally against the current manifest: `22.1.2-rust-1.96.1-stable` yields `1.96.1`.
- `yaml.safe_load` on the workflow, and the step order checked so the resolve step precedes the toolchain install.
- The other five jobs of that run succeeded: `resolve` (both preflights passed, including the Windows patch), `bindings` (exercising the new `--write`), both Linux rebuilds, and the Windows rebuild in 14m16s (exercising the new `-AllowHashDrift`).

The macOS lane itself is still unproven end to end. A fresh dry run follows this merge.