### PR TITLE
fix(libghostty): pin RUSTUP_TOOLCHAIN in the bump macOS lane

### DIFF
--- a/.github/workflows/libghostty-bump.yml
+++ b/.github/workflows/libghostty-bump.yml
@@ -366,6 +366,11 @@ jobs:
       - name: Build and prove reproducibility
         env:
           PANEFLOW_GHOSTTY_SOURCE_DIR: ${{ github.workspace }}/.ghostty-source
+          # The build script resolves llvm-strip through `rustc --print
+          # sysroot`, and the directory `rust-toolchain.toml` outranks the
+          # toolchain the step above made default. Only RUSTUP_TOOLCHAIN wins,
+          # the same way libghostty-macos.yml pins its own rebuild lane.
+          RUSTUP_TOOLCHAIN: ${{ steps.llvm.outputs.rust }}
         run: |
           scripts/ci-retry-network.sh \
             scripts/build-libghostty-macos.sh \


### PR DESCRIPTION
Second dry run ([run 33528229313](https://github.com/arthjean/paneflow/actions/runs/33528229313)) still failed the macOS lane, with a different symptom than the first:

```
info: syncing channel updates for 1.98.0-x86_64-unknown-linux-gnu
libghostty requires llvm-strip from LLVM 22.1.2-rust-1.96.1-stable
install the rustup llvm-tools component or set PANEFLOW_LLVM_BIN
```

The previous fix installed 1.96.1 with llvm-tools, but rustup still resolved 1.98.0: the build script finds llvm-strip through `rustc --print sysroot`, and the directory `rust-toolchain.toml` outranks whatever toolchain a step made default. Only `RUSTUP_TOOLCHAIN` wins.

`libghostty-macos.yml` already pins it on its own rebuild lane and documents this exact trap. The bump lane now does the same, using the version derived from `macos_llvm_version` so there is still a single source for it.

## Validation

Rather than fix one more symptom blind, I diffed the bump macOS job against the existing `native-rebuild` job step by step. They are now identical in structure and in step environment. The remaining differences are the ones a bump requires: it consumes the staged manifest, and it does not compare against the committed archive it is about to replace.

The other five jobs succeeded again in that run, so `resolve`, `bindings`, both Linux lanes and the Windows lane are now green twice over. The macOS lane remains unproven end to end; a fresh dry run follows this merge.