### PR TITLE
ci(smoke): fetch Tumbleweed from the MirrorCache origin instead of community mirrors

### DIFF
--- a/.github/workflows/libghostty-linux.yml
+++ b/.github/workflows/libghostty-linux.yml
@@ -508,19 +508,26 @@ jobs:
               notice=/usr/share/doc/paneflow/THIRD_PARTY_NOTICES.md
               ;;
             opensuse)
-              # Tumbleweed rolls daily and the mirror drops superseded repodata
-              # faster than the `:latest` image's baked cache is rebuilt, so the
-              # install fails with "not found on medium", skips the OSS repo,
-              # and then reports "No provider of 'binutils' found" (exit 104).
-              # A forced refresh re-reads repomd.xml; the retry covers the
-              # window where the mirror is mid-sync. Observed twice.
+              # download.opensuse.org and cdn.opensuse.org answer every repodata
+              # and RPM request with a 302 to a nearby community mirror, and from
+              # a US-hosted runner that mirror is regularly lagging or dead: both
+              # 2026-09-03 failures burned 60 s connect timeouts on the 9 MB
+              # appdata.xml.gz through all three retries, and a rerun on another
+              # runner passed. libzypp downloads appdata unconditionally, so the
+              # fix is the host: downloadcontentcdn.opensuse.org is the MirrorCache
+              # origin behind Fastly and serves every file itself. The `:latest`
+              # image's baked metadata still goes stale, so the forced refresh
+              # stays, and the retry now only covers a publish in progress.
+              sed -i 's#^baseurl=https\?://download\.opensuse\.org/#baseurl=https://downloadcontentcdn.opensuse.org/#' /etc/zypp/repos.d/*.repo
+              grep -q 'downloadcontentcdn' /etc/zypp/repos.d/*.repo
+              zypper --non-interactive repos --uri
               refreshed=0
               for attempt in 1 2 3; do
                 if zypper --non-interactive --no-gpg-checks refresh --force; then
                   refreshed=1
                   break
                 fi
-                echo "::warning::zypper refresh failed (attempt $attempt/3); Tumbleweed mirror is probably mid-sync"
+                echo "::warning::zypper refresh failed (attempt $attempt/3)"
                 sleep $((attempt * 20))
               done
               if [ "$refreshed" -ne 1 ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2198,11 +2198,17 @@ jobs:
     steps:
       - name: Refresh zypper repos (retry on transient mirror flake)
         # Tumbleweed's container image ships with stale repo metadata
-        # roughly half the time; refresh once, retry on flake. The OSS
-        # repo also serves a large AppStream metadata blob that can exceed
-        # libzypp's default transfer timeout from GitHub-hosted runners.
+        # roughly half the time; refresh once, retry on flake. The repo
+        # files point at download.opensuse.org, which redirects every file
+        # to a community mirror that is regularly lagging or dead from
+        # US-hosted runners (60 s connect timeouts on appdata.xml.gz);
+        # downloadcontentcdn.opensuse.org is the MirrorCache origin behind
+        # Fastly and serves every file itself. Same fix as the package
+        # smoke in libghostty-linux.yml.
         run: |
           set -euo pipefail
+          sed -i 's#^baseurl=https\?://download\.opensuse\.org/#baseurl=https://downloadcontentcdn.opensuse.org/#' /etc/zypp/repos.d/*.repo
+          grep -q 'downloadcontentcdn' /etc/zypp/repos.d/*.repo
           mkdir -p /etc/zypp
           touch /etc/zypp/zypp.conf
           sed -i \


### PR DESCRIPTION
## Behavior

The openSUSE package smoke (`libghostty-linux.yml`) and the release smoke (`release.yml`) now rewrite the Tumbleweed repo files to `https://downloadcontentcdn.opensuse.org/` before refreshing, instead of leaving them on `download.opensuse.org`. Nothing else in either job changes; the forced refresh and the three-attempt retry stay.

## Why

Two failures today on `Package smoke (opensuse, x86_64)`, PR #53 run 33732894901 and PR #54 run 33746027507, each through all three refresh attempts, each fixed by a rerun on another runner:

```
[repo-oss|http://download.opensuse.org/tumbleweed/repo/oss/] Failed to retrieve new repository metadata.
 - Timeout exceeded when accessing 'http://cdn.opensuse.org/tumbleweed/repo/oss/repodata/a6510dc9…-appdata.xml.gz'.
   Timeout reached Curl error (28)
```

Timings in both logs are exact multiples of libzypp's 60 s `download.connect_timeout` (Non-Oss 61 s, Oss 121 s), and `appdata.xml.gz` is 8.6 MB, so this is a connection that never opens, not a slow transfer. Both `download.opensuse.org` and `cdn.opensuse.org` answer that file with a 302 to a community mirror (`fr2.rpmfind.net` from here); from US-hosted runners MirrorCache routes to US mirrors that lag or are dead, as documented in [systemd/mkosi#4365](https://github.com/systemd/mkosi/issues/4365) and confirmed by the MirrorCache maintainer in [openSUSE/MirrorCache#638](https://github.com/openSUSE/MirrorCache/issues/638#issuecomment-3708979797). libzypp downloads appdata unconditionally (`zypp/repo/yum/RepomdFileCollector.cc` only skips `other`, `filelists`, `*_db` and foreign `susedata.LOCALE`), so the file cannot be trimmed and longer timeouts only make each failure slower.

`downloadcontentcdn.opensuse.org` is the MirrorCache origin behind Fastly (151.101.121.91, `X-Served-By: cache-par-…`): it serves `repomd.xml`, `appdata.xml.gz` and RPMs itself with a 200 for `tumbleweed/repo/oss`, `tumbleweed/repo/non-oss` and `update/tumbleweed`, and it is the host `mirrorcache-us.opensuse.org` redirects to for `repomd.xml`.

## Validation

- Redirect chain and direct-serve probes with `curl -sIL` on both hosts for `repomd.xml`, the current `appdata.xml.gz` and `binutils-2.45-4.3.x86_64.rpm`.
- The `sed` expression exercised against the `http://` and `https://` `baseurl` forms, and against the `codecs.opensuse.org` line it must leave alone.
- Both workflow files parsed as YAML.
- The `Package smoke (opensuse, x86_64)` job of this PR is the end-to-end check; the step now prints `zypper repos --uri` so the log shows which host served the refresh. No Docker on the development machine, so the container recipe was not run locally.
- The release smoke only runs on a tag and was reviewed by inspection.
