### PR TITLE
fix(worktree): translate git-reported checkout paths into Paneflow's form

### DIFF
--- a/src-app/src/workspace/worktree.rs
+++ b/src-app/src/workspace/worktree.rs
@@ -267,6 +267,40 @@ fn worktrees_parent(repo_root: &Path) -> PathBuf {
     }
 }
 
+fn in_paneflow_path_form(repo_root: &Path, path: PathBuf) -> PathBuf {
+    let roots = [
+        worktrees_parent(repo_root),
+        legacy_worktrees_parent(repo_root),
+        repo_root.to_path_buf(),
+    ];
+    for root in roots {
+        if path.starts_with(&root) {
+            return path;
+        }
+        let Ok(resolved) = std::fs::canonicalize(&root) else {
+            continue;
+        };
+        if let Ok(rest) = path.strip_prefix(without_verbatim_prefix(resolved)) {
+            return root.join(rest);
+        }
+    }
+    path
+}
+
+#[cfg(windows)]
+fn without_verbatim_prefix(path: PathBuf) -> PathBuf {
+    let text = path.to_string_lossy();
+    match text.strip_prefix(r"\\?\") {
+        Some(rest) if rest.as_bytes().get(1) == Some(&b':') => PathBuf::from(rest),
+        _ => path,
+    }
+}
+
+#[cfg(not(windows))]
+fn without_verbatim_prefix(path: PathBuf) -> PathBuf {
+    path
+}
+
 pub fn worktree_dir(repo_root: &Path, branch: &str) -> PathBuf {
     worktrees_parent(repo_root).join(branch_slug_or_default(branch))
 }
@@ -656,7 +690,13 @@ pub fn list_worktrees(repo_root: &Path) -> Result<Vec<WorktreeEntry>, String> {
         &["worktree", "list", "--porcelain"],
         GIT_DEADLINE,
     )?;
-    Ok(parse_worktree_porcelain(&stdout))
+    Ok(parse_worktree_porcelain(&stdout)
+        .into_iter()
+        .map(|entry| WorktreeEntry {
+            path: in_paneflow_path_form(repo_root, entry.path),
+            branch: entry.branch,
+        })
+        .collect())
 }
 
 pub fn parse_worktree_porcelain(stdout: &str) -> Vec<WorktreeEntry> {
@@ -1104,6 +1144,36 @@ mod tests {
         assert_eq!(branch_slug("."), "");
         assert_eq!(branch_slug("..."), "");
         assert_eq!(branch_slug("-..-"), "");
+    }
+
+    #[test]
+    fn a_resolved_git_path_comes_back_in_paneflow_path_form() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _root = test_support::scoped_root(tmp.path().join("worktrees"));
+        let repo_root = tmp.path().join("repo");
+        let dir = worktree_dir(&repo_root, "feat/x");
+        std::fs::create_dir_all(&dir).expect("worktree dir");
+
+        let parent = worktrees_parent(&repo_root);
+        let resolved = without_verbatim_prefix(std::fs::canonicalize(&parent).expect("canonical"));
+        let as_git_reports_it = resolved.join("feat-x");
+
+        assert_eq!(in_paneflow_path_form(&repo_root, as_git_reports_it), dir);
+        assert_eq!(
+            in_paneflow_path_form(&repo_root, dir.clone()),
+            dir,
+            "a path already in Paneflow form is untouched"
+        );
+    }
+
+    #[test]
+    fn a_path_outside_every_paneflow_root_is_left_alone() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _root = test_support::scoped_root(tmp.path().join("worktrees"));
+        let repo_root = tmp.path().join("repo");
+        let outside = tmp.path().join("somewhere-else").join("checkout");
+
+        assert_eq!(in_paneflow_path_form(&repo_root, outside.clone()), outside);
     }
 
     #[test]


### PR DESCRIPTION
`tests_pass` has been red on main since `9d64180c` (2026-09-09). Two worktree
tests fail on the macOS and Windows legs, and the cause is a real bug, not a
test artifact.

## What is wrong

Paneflow handles two path vocabularies without ever reconciling them.
Constructed paths come from `worktrees_root()` and are never resolved.
Reported paths come from `git worktree list --porcelain`, and git resolves
them. Where the worktrees root reaches the filesystem through a symlink or an
8.3 short name, the two forms never compare equal:

```
macOS    git: /private/var/folders/.../worktrees/repo-72ad421e/feat-from-develop
       ours: /var/folders/.../worktrees/repo-72ad421e/feat-from-develop

Windows  git: C:\Users\runneradmin\AppData\Local\Temp\.../feat-from-develop
       ours: C:\Users\RUNNER~1\AppData\Local\Temp\.../feat-from-develop
```

`plan_branch_checkout` returns `Existing(entry.path)` in git's form and
`Create(worktree_dir(...))` in ours. So for an affected user, asking for a
branch that already has a live checkout does not recognize the worktree
Paneflow created a moment earlier: it plans a duplicate, or trips the "exists
but holds another branch" guard. The same mismatch breaks
`is_paneflow_worktree_dir`, which decides whether a directory is ours to
manage, and therefore session restore of a managed worktree.

macOS users are hit whenever the worktrees root sits under `/var` or any
symlinked volume. Windows users are hit whenever the profile path needs an 8.3
short name, so a user named `Administrator` is affected and one named `Arthur`
is not, which is why this landed green.

## The fix

`list_worktrees` translates each reported path back onto the Paneflow root it
belongs to: the worktrees parent, the legacy worktrees parent, or the repo
root. A root is matched by canonicalizing it once and stripping that prefix,
then the remainder is re-joined onto the unresolved root. Anything under none
of them is returned untouched.

That puts the normalization at the single boundary where git's vocabulary
enters the app, so every downstream comparison keeps working on plain `==`.
Constructed paths are left alone, which matters: resolving them at
construction would make `worktree_dir` return a different string before and
after the directory exists, and that instability is what broke five unrelated
tests in the two earlier attempts on this branch.

On Linux, and on a Windows profile that needs no short name, `canonicalize`
returns the path unchanged and every value is byte-identical to before.

## Validation

The failure is reproducible on this Windows host by pointing `TMP`/`TEMP` at a
directory junction, which diverges from its canonical form exactly the way
`/var` -> `/private/var` does on macOS. On `main`'s code that harness fails 4
worktree tests; with this commit the full workspace suite is clean through it.

- `cargo fmt --check` and `cargo clippy --workspace --all-targets --locked -- -D warnings`: clean.
- `cargo test --workspace --locked --no-fail-fast`: clean on the normal temp path.
- `cargo test --workspace --locked --no-fail-fast` with `TMP`/`TEMP` on the junction: clean.
- Two regression tests added: a git-form path round-trips back to the
  constructed form, and a path under no Paneflow root is left alone.

Found while getting #61 green; that branch is blocked on this one.
