### PR TITLE
fix(keybindings): enable native terminal paste shortcuts

### DIFF
--- a/src-app/src/keybindings/apply.rs
+++ b/src-app/src/keybindings/apply.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use gpui::{Action, App, DummyKeyboardMapper, KeyBinding, KeyBindingContextPredicate, Keystroke};
 
-use super::defaults::{DEFAULTS, MACOS_ONLY_DEFAULTS};
+use super::defaults::{DEFAULTS, PLATFORM_DEFAULTS};
 use super::registry::{action_from_name, context_for_action};
 
 pub(super) fn normalize_keystroke(keystrokes: &str) -> String {
@@ -87,7 +87,7 @@ pub fn apply_keybindings(cx: &mut App, user_shortcuts: &HashMap<String, String>)
 
     let default_bindings: Vec<KeyBinding> = DEFAULTS
         .iter()
-        .chain(MACOS_ONLY_DEFAULTS.iter())
+        .chain(PLATFORM_DEFAULTS.iter())
         .filter(|d| !is_unbound(d.key))
         .filter(|d| !remapped_actions.contains(d.action_name))
         .filter(|d| !is_user_claimed(d.key))
@@ -241,7 +241,7 @@ mod tests {
 
             let claimants: Vec<&str> = DEFAULTS
                 .iter()
-                .chain(MACOS_ONLY_DEFAULTS.iter())
+                .chain(PLATFORM_DEFAULTS.iter())
                 .filter(|d| keystrokes_conflict(d.key, key))
                 .map(|d| d.action_name)
                 .collect();

--- a/src-app/src/keybindings/defaults.rs
+++ b/src-app/src/keybindings/defaults.rs
@@ -403,7 +403,7 @@ pub(super) const DEFAULTS: &[DefaultBinding] = &[
 ];
 
 #[cfg(target_os = "macos")]
-pub(super) const MACOS_ONLY_DEFAULTS: &[DefaultBinding] = &[
+pub(super) const PLATFORM_DEFAULTS: &[DefaultBinding] = &[
     DefaultBinding {
         key: "cmd-c",
         action_name: "terminal_copy",
@@ -422,7 +422,11 @@ pub(super) const MACOS_ONLY_DEFAULTS: &[DefaultBinding] = &[
 ];
 
 #[cfg(not(target_os = "macos"))]
-pub(super) const MACOS_ONLY_DEFAULTS: &[DefaultBinding] = &[];
+pub(super) const PLATFORM_DEFAULTS: &[DefaultBinding] = &[DefaultBinding {
+    key: "ctrl-v",
+    action_name: "terminal_paste",
+    context: Some("Terminal"),
+}];
 
 #[cfg(test)]
 mod tests {
@@ -509,14 +513,14 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn us010_cmd_c_cmd_v_bound_on_macos() {
-        let copy = MACOS_ONLY_DEFAULTS
+        let copy = PLATFORM_DEFAULTS
             .iter()
             .find(|d| d.key == "cmd-c")
             .expect("cmd-c must be a macOS default");
         assert_eq!(copy.action_name, "terminal_copy");
         assert_eq!(copy.context, Some("Terminal"));
 
-        let paste = MACOS_ONLY_DEFAULTS
+        let paste = PLATFORM_DEFAULTS
             .iter()
             .find(|d| d.key == "cmd-v")
             .expect("cmd-v must be a macOS default");
@@ -537,19 +541,21 @@ mod tests {
 
     #[cfg(not(target_os = "macos"))]
     #[test]
-    fn us010_no_cmd_bindings_on_linux() {
-        assert!(
-            MACOS_ONLY_DEFAULTS.is_empty(),
-            "Linux build should carry zero macOS-only defaults, got {} entries",
-            MACOS_ONLY_DEFAULTS.len()
-        );
+    fn non_macos_defaults_bind_ctrl_v_without_cmd_bindings() {
+        let paste = PLATFORM_DEFAULTS
+            .iter()
+            .find(|d| d.key == "ctrl-v")
+            .expect("ctrl-v must be a non-macOS default");
+        assert_eq!(paste.action_name, "terminal_paste");
+        assert_eq!(paste.context, Some("Terminal"));
+        assert!(PLATFORM_DEFAULTS.iter().all(|d| !d.key.starts_with("cmd-")));
     }
 
     #[test]
     fn us010_ctrl_c_never_bound_to_terminal_copy() {
         let leaked_actions: Vec<&'static str> = DEFAULTS
             .iter()
-            .chain(MACOS_ONLY_DEFAULTS.iter())
+            .chain(PLATFORM_DEFAULTS.iter())
             .filter(|d| d.key == "ctrl-c")
             .map(|d| d.action_name)
             .collect();
@@ -574,6 +580,6 @@ mod tests {
 
     #[test]
     fn us012_quit_is_not_also_a_platform_default() {
-        assert!(MACOS_ONLY_DEFAULTS.iter().all(|d| d.action_name != "quit"));
+        assert!(PLATFORM_DEFAULTS.iter().all(|d| d.action_name != "quit"));
     }
 }

--- a/src-app/src/keybindings/display.rs
+++ b/src-app/src/keybindings/display.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use gpui::Keystroke;
 
 use super::apply::canonical_keystroke;
-use super::defaults::{DEFAULTS, MACOS_ONLY_DEFAULTS};
+use super::defaults::{DEFAULTS, PLATFORM_DEFAULTS};
 use super::registry::{ACTIONS, action_description};
 
 pub struct ShortcutEntry {
@@ -134,12 +134,12 @@ pub fn effective_shortcuts(user_shortcuts: &HashMap<String, String>) -> Vec<Shor
     let mut entries = Vec::new();
     let mut seen_actions: HashSet<&'static str> = HashSet::new();
 
-    let macos_key_by_action: HashMap<&str, &str> = MACOS_ONLY_DEFAULTS
+    let platform_key_by_action: HashMap<&str, &str> = PLATFORM_DEFAULTS
         .iter()
         .map(|d| (d.action_name, d.key))
         .collect();
 
-    for d in DEFAULTS.iter().chain(MACOS_ONLY_DEFAULTS.iter()) {
+    for d in DEFAULTS.iter().chain(PLATFORM_DEFAULTS.iter()) {
         let Some(meta) = ACTIONS.iter().find(|a| a.name == d.action_name) else {
             continue;
         };
@@ -148,7 +148,7 @@ pub fn effective_shortcuts(user_shortcuts: &HashMap<String, String>) -> Vec<Shor
             continue;
         }
 
-        let default_key = match macos_key_by_action.get(d.action_name).copied() {
+        let default_key = match platform_key_by_action.get(d.action_name).copied() {
             Some(native) if !is_unbound(native) && !is_user_claimed(native) => native,
             _ => d.key,
         };
@@ -156,7 +156,7 @@ pub fn effective_shortcuts(user_shortcuts: &HashMap<String, String>) -> Vec<Shor
         let key = if let Some(user_key) = user_by_action.get(d.action_name) {
             format_keystroke(user_key)
         } else {
-            if is_unbound(d.key) || is_user_claimed(d.key) {
+            if is_unbound(default_key) || is_user_claimed(default_key) {
                 continue;
             }
             format_keystroke(default_key)
@@ -219,6 +219,47 @@ pub fn is_bare_modifier(keystroke: &Keystroke) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn paste_shortcut_display_tracks_available_bindings() {
+        let native = if cfg!(target_os = "macos") {
+            "cmd-v"
+        } else {
+            "ctrl-v"
+        };
+        let alternate = "ctrl-shift-v";
+        let cases = [
+            (vec![], Some(native)),
+            (vec![(native, "none")], Some(alternate)),
+            (vec![(alternate, "none")], Some(native)),
+            (vec![(native, "none"), (alternate, "none")], None),
+            (vec![(native, "split_horizontally")], Some(alternate)),
+            (vec![(alternate, "split_horizontally")], Some(native)),
+            (vec![("ctrl-alt-v", "terminal_paste")], Some("ctrl-alt-v")),
+        ];
+        for (overrides, expected) in cases {
+            let overrides = overrides
+                .into_iter()
+                .map(|(key, action)| (key.to_string(), action.to_string()))
+                .collect();
+            let entries = effective_shortcuts(&overrides);
+            let paste: Vec<_> = entries
+                .iter()
+                .filter(|entry| entry.action_name == "terminal_paste")
+                .collect();
+            assert_eq!(paste.len(), 1);
+            assert_eq!(
+                paste[0].key,
+                expected.map_or_else(|| "Unassigned".to_string(), format_keystroke),
+                "overrides: {overrides:?}"
+            );
+            assert_eq!(
+                paste[0].search_key,
+                expected.map_or_else(String::new, ascii_key_forms),
+                "overrides: {overrides:?}"
+            );
+        }
+    }
 
     #[test]
     fn effective_shortcuts_defaults_include_core_actions() {
@@ -336,7 +377,7 @@ mod tests {
 
     #[test]
     fn every_default_chord_round_trips_through_parse() {
-        for d in DEFAULTS.iter().chain(MACOS_ONLY_DEFAULTS.iter()) {
+        for d in DEFAULTS.iter().chain(PLATFORM_DEFAULTS.iter()) {
             let parsed = Keystroke::parse(d.key)
                 .unwrap_or_else(|_| panic!("default chord {} does not parse", d.key));
             let round_tripped = Keystroke::parse(&parsed.unparse())


### PR DESCRIPTION
## Summary

Enable Ctrl+V to paste into terminal panes on Windows and Linux, including tools that finish dictation by simulating Ctrl+V. Keep Cmd+V on macOS and Ctrl+Shift+V on every platform.

Refs #64

## User-visible behavior

Settings shows the native paste shortcut and falls back to Ctrl+Shift+V when the native binding is disabled or reassigned. User overrides retain precedence. Ctrl+C remains available to the terminal.

On Windows and Linux, Ctrl+V now invokes paste instead of reaching the shell or TUI. Users can restore that behavior with `"shortcuts": { "ctrl-v": "none" }`.

## Validation

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --locked`
- [ ] Manual UI and Superwhisper verification

Clippy and workspace tests passed on Windows during implementation. Formatting was rechecked before commit in an isolated checkout containing only this patch, because unrelated local edits fail formatting. Tests cover platform defaults, Ctrl+C preservation, and paste shortcut display under disabling and reassignment.

## Cross-platform check

- Linux (Wayland/X11): shared non-macOS binding path inspected; not run.
- macOS: existing Cmd+V defaults preserved; platform-specific code inspected, not run.
- Windows: compilation, Clippy, and tests passed on the development host; Windows 10/11 runtime behavior was not separately qualified.

## Screenshots / recordings

No manual capture was taken. The change affects keyboard defaults and the shortcut text shown in Settings.
