### PR TITLE
fix(windows): harden workspace editor and folder launches

### DIFF
--- a/src-app/Cargo.toml
+++ b/src-app/Cargo.toml
@@ -323,6 +323,7 @@ objc2-metal = { version = "0.3.2", default-features = false, features = [
 raw-window-handle = "0.6"
 windows-sys = { version = "0.59", features = [
     "Win32_System_Threading",
+    "Win32_System_JobObjects",
     "Win32_Foundation",
     # `timeBeginPeriod` / `timeEndPeriod`: hold the process timer resolution at
     # 1 ms for the GUI's lifetime so the terminal loops' millisecond timeouts

--- a/src-app/src/app/sidebar/context_menu.rs
+++ b/src-app/src/app/sidebar/context_menu.rs
@@ -294,7 +294,11 @@ impl PaneFlowApp {
             .map(|s| SharedString::from(s.to_string()));
         context_menu = context_menu.child(self.render_select_menu_item(
             "workspace-context-reveal".into(),
-            "Reveal in File Manager",
+            if cfg!(target_os = "windows") {
+                "Open in File Explorer"
+            } else {
+                "Reveal in File Manager"
+            },
             reveal_shortcut,
             ui,
             cx.listener(move |this, _: &ClickEvent, _window, cx| {

--- a/src-app/src/app/workspace_ops/mod.rs
+++ b/src-app/src/app/workspace_ops/mod.rs
@@ -5,7 +5,6 @@ mod tab;
 
 use gpui::{App, AppContext, ClipboardItem, Context, Entity, Focusable, PathPromptOptions, Window};
 use paneflow_config::schema::{TabTitleSource, TerminalSurfaceProfile};
-use paneflow_process::spawn_detached;
 
 use crate::layout::{LayoutTree, MAX_PANES, SplitDirection};
 use crate::terminal::TerminalView;
@@ -825,11 +824,15 @@ impl PaneFlowApp {
         let cwd = ws.cwd.clone();
         self.workspace_menu_open = None;
 
-        if let Err(msg) = reveal_in_file_manager(std::path::Path::new(&cwd)) {
-            log::warn!("failed to reveal workspace path in file manager: {msg}");
-            self.show_toast(msg, cx);
-        }
-
+        let task = cx
+            .background_executor()
+            .spawn(async move { reveal_in_file_manager(std::path::Path::new(&cwd)).await });
+        cx.spawn(async move |this, cx| {
+            if let Err(message) = task.await {
+                let _ = this.update(cx, |app, cx| app.show_toast(message, cx));
+            }
+        })
+        .detach();
         cx.notify();
     }
 
@@ -845,15 +848,34 @@ impl PaneFlowApp {
         };
         let cwd = ws.cwd.clone();
 
-        let bin = resolve_editor_binary(command);
-
-        let toast_label = editor_toast_label(label);
-        let mut cmd = std::process::Command::new(&bin);
-        cmd.current_dir(&cwd).arg(".");
-        if let Err(err) = spawn_detached(&mut cmd) {
-            log::warn!("failed to open workspace in {toast_label}: {err}");
-            self.show_toast(format!("Couldn't open in {toast_label}: {err}"), cx);
-        }
+        let command = command.to_owned();
+        let toast_label = editor_toast_label(label).to_owned();
+        let task = cx.background_executor().spawn(async move {
+            let cmd = smol::unblock(move || {
+                let bin = resolve_editor_binary(&command);
+                log::info!(
+                    "workspace editor resolved: editor={command:?} binary={bin:?} cwd={cwd:?}"
+                );
+                let mut cmd = std::process::Command::new(bin);
+                cmd.current_dir(cwd).arg(".");
+                cmd
+            })
+            .await;
+            match crate::external_open::run_workspace_command(cmd).await {
+                Ok(status) if status.success() => Ok(()),
+                Ok(status) => Err(format!(
+                    "Couldn't open in {toast_label}: launcher exited with {status}"
+                )),
+                Err(error) => Err(format!("Couldn't open in {toast_label}: {error}")),
+            }
+        });
+        cx.spawn(async move |this, cx| {
+            if let Err(message) = task.await {
+                log::warn!("{message}");
+                let _ = this.update(cx, |app, cx| app.show_toast(message, cx));
+            }
+        })
+        .detach();
 
         self.workspace_menu_open = None;
         cx.notify();
@@ -973,10 +995,10 @@ impl PaneFlowApp {
 }
 
 #[allow(clippy::needless_return)]
-pub(crate) fn reveal_in_file_manager(path: &std::path::Path) -> Result<(), String> {
+pub(crate) async fn reveal_in_file_manager(path: &std::path::Path) -> Result<(), String> {
     #[cfg(target_os = "linux")]
     {
-        let result = spawn_detached(std::process::Command::new("xdg-open").arg(path));
+        let result = open_workspace_folder("xdg-open", path).await;
         return result.map_err(|err| {
             if err.kind() == std::io::ErrorKind::NotFound {
                 "xdg-open not found - install xdg-utils to use this feature".to_string()
@@ -987,21 +1009,38 @@ pub(crate) fn reveal_in_file_manager(path: &std::path::Path) -> Result<(), Strin
     }
     #[cfg(target_os = "macos")]
     {
-        let result = spawn_detached(std::process::Command::new("open").arg(path));
+        let result = open_workspace_folder("open", path).await;
         return result.map_err(|err| format!("Could not open Finder: {err}"));
     }
     #[cfg(target_os = "windows")]
     {
-        let mut flag = std::ffi::OsString::from("/select,");
-        flag.push(path.as_os_str());
-        let result = spawn_detached(std::process::Command::new("explorer").arg(flag));
+        let result = open_workspace_folder("explorer.exe", path).await;
         return result.map_err(|err| format!("Could not open Explorer: {err}"));
     }
     #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
     {
-        spawn_detached(std::process::Command::new("xdg-open").arg(path))
+        open_workspace_folder("xdg-open", path)
+            .await
             .map_err(|err| format!("Could not open file manager: {err}"))
     }
+}
+
+pub(crate) async fn open_workspace_folder(
+    command: &str,
+    path: &std::path::Path,
+) -> std::io::Result<()> {
+    let mut cmd = std::process::Command::new(command);
+    cmd.arg(path);
+    let status = crate::external_open::run_workspace_command(cmd).await?;
+    #[cfg(not(target_os = "windows"))]
+    if !status.success() {
+        return Err(std::io::Error::other(format!(
+            "{command} exited with {status}"
+        )));
+    }
+    #[cfg(target_os = "windows")]
+    let _ = status;
+    Ok(())
 }
 
 pub(crate) fn resolve_editor_binary(command: &str) -> std::path::PathBuf {
@@ -1146,13 +1185,6 @@ mod tests {
             format!("Could not open file manager: {err}")
         };
         assert!(msg.contains("xdg-utils"), "unhappy-path AC text: {msg}");
-    }
-
-    #[test]
-    fn reveal_accepts_regular_path() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let _callable: fn(&std::path::Path) -> Result<(), String> = reveal_in_file_manager;
-        let _ = tmp.path();
     }
 
     const EXE_SUFFIX: &str = if cfg!(windows) { ".exe" } else { "" };

--- a/src-app/src/external_open.rs
+++ b/src-app/src/external_open.rs
@@ -1,5 +1,56 @@
-#[cfg(target_os = "windows")]
-use std::process::{Command, Stdio};
+use std::process::{Command, ExitStatus, Stdio};
+
+pub(crate) async fn run_workspace_command(mut command: Command) -> std::io::Result<ExitStatus> {
+    let description = format!(
+        "binary={:?} cwd={:?} args={:?}",
+        command.get_program(),
+        command.get_current_dir(),
+        command.get_args().collect::<Vec<_>>()
+    );
+    log::info!("workspace launch: {description}");
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        use windows_sys::Win32::System::Threading::{
+            CREATE_BREAKAWAY_FROM_JOB, CREATE_NEW_PROCESS_GROUP, DETACHED_PROCESS,
+        };
+        command.creation_flags(
+            CREATE_BREAKAWAY_FROM_JOB | CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS,
+        );
+    }
+    let result = smol::unblock(move || command.spawn()).await;
+    let mut child = match result {
+        Ok(child) => child,
+        Err(error) => {
+            log::warn!(
+                "workspace launch failed: {description} error={error} os_error={:?}",
+                error.raw_os_error()
+            );
+            return Err(error);
+        }
+    };
+    log::info!("workspace spawned: {description} pid={}", child.id());
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                log::info!(
+                    "workspace process exited: {description} pid={} status={status}",
+                    child.id()
+                );
+                return Ok(status);
+            }
+            Ok(None) => smol::Timer::after(std::time::Duration::from_millis(500)).await,
+            Err(error) => {
+                log::warn!("workspace process wait failed: {description} error={error}");
+                return Err(error);
+            }
+        };
+    }
+}
 
 #[cfg(target_os = "windows")]
 pub(crate) const OPEN_URL_SUBCOMMAND: &str = "__paneflow-open-url";
@@ -57,6 +108,150 @@ pub(crate) fn run_open_url_helper_from_args(args: &[String]) -> i32 {
 #[cfg(all(test, target_os = "windows"))]
 mod tests {
     use super::*;
+
+    #[test]
+    fn workspace_native_launcher_escapes_app_job() {
+        launch_in_app_job("native");
+    }
+
+    #[test]
+    fn workspace_batch_launcher_receives_cwd_and_reports_failure() {
+        launch_in_app_job("batch");
+    }
+
+    #[test]
+    fn workspace_folder_opener_receives_directory_with_spaces() {
+        launch_in_app_job("folder");
+    }
+
+    fn launch_in_app_job(kind: &str) {
+        let temp = tempfile::tempdir().unwrap();
+        let cwd = temp.path().join("workspace space & (é)");
+        std::fs::create_dir(&cwd).unwrap();
+        let status = Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "external_open::tests::workspace_job_parent",
+                "--ignored",
+            ])
+            .env("PANEFLOW_TEST_WORKSPACE_CWD", &cwd)
+            .env("PANEFLOW_TEST_WORKSPACE_LAUNCH_KIND", kind)
+            .status()
+            .unwrap();
+        assert!(
+            status.success(),
+            "workspace launch in app job failed: {status}"
+        );
+    }
+
+    #[test]
+    #[ignore = "subprocess with the app's process job"]
+    fn workspace_job_parent() {
+        let Some(cwd) = std::env::var_os("PANEFLOW_TEST_WORKSPACE_CWD") else {
+            return;
+        };
+        use windows_sys::Win32::System::JobObjects::{
+            JOBOBJECT_BASIC_ACCOUNTING_INFORMATION, JobObjectBasicAccountingInformation,
+            QueryInformationJobObject,
+        };
+        let mut limits = win32job::ExtendedLimitInfo::default();
+        limits.limit_kill_on_job_close().limit_breakaway_ok();
+        let job = win32job::Job::create_with_limit_info(&limits).unwrap();
+        job.assign_current_process().unwrap();
+        let handle = job.into_handle();
+        match std::env::var("PANEFLOW_TEST_WORKSPACE_LAUNCH_KIND")
+            .unwrap()
+            .as_str()
+        {
+            "batch" => check_batch_launcher(std::path::Path::new(&cwd)),
+            "folder" => check_folder_opener(std::path::Path::new(&cwd)),
+            "native" => {
+                let mut command = Command::new(std::env::current_exe().unwrap());
+                command
+                    .args([
+                        "--exact",
+                        "external_open::tests::workspace_job_child",
+                        "--ignored",
+                    ])
+                    .current_dir(cwd);
+                let status = smol::block_on(run_workspace_command(command)).unwrap();
+                assert!(status.success(), "workspace child failed: {status}");
+            }
+            other => panic!("unknown launch kind: {other}"),
+        }
+        let mut accounting: JOBOBJECT_BASIC_ACCOUNTING_INFORMATION = unsafe { std::mem::zeroed() };
+        assert_ne!(
+            unsafe {
+                QueryInformationJobObject(
+                    handle as _,
+                    JobObjectBasicAccountingInformation,
+                    (&raw mut accounting).cast(),
+                    std::mem::size_of_val(&accounting) as u32,
+                    std::ptr::null_mut(),
+                )
+            },
+            0
+        );
+        assert_eq!(
+            accounting.TotalProcesses, 1,
+            "external launcher inherited Paneflow's job"
+        );
+    }
+
+    #[test]
+    #[ignore = "native executable launched from the app's process job"]
+    fn workspace_job_child() {
+        let Some(cwd) = std::env::var_os("PANEFLOW_TEST_WORKSPACE_CWD") else {
+            return;
+        };
+        assert_eq!(
+            std::env::current_dir().unwrap(),
+            std::path::PathBuf::from(cwd)
+        );
+    }
+
+    #[test]
+    fn workspace_command_reports_missing_executable() {
+        let error = smol::block_on(run_workspace_command(Command::new(
+            "paneflow-missing-workspace-editor-67",
+        )))
+        .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
+    }
+
+    fn check_batch_launcher(cwd: &std::path::Path) {
+        let temp = tempfile::tempdir().unwrap();
+        let launcher = temp.path().join("editor launcher.cmd");
+        std::fs::write(&launcher, "@echo off\r\necho %~1> arg.txt\r\nexit /b 7\r\n").unwrap();
+        let mut command = Command::new(launcher);
+        command.current_dir(cwd).arg(".");
+        let status = smol::block_on(run_workspace_command(command)).unwrap();
+        assert_eq!(status.code(), Some(7));
+        assert_eq!(
+            std::fs::read_to_string(cwd.join("arg.txt")).unwrap().trim(),
+            "."
+        );
+    }
+
+    fn check_folder_opener(folder: &std::path::Path) {
+        let temp = tempfile::tempdir().unwrap();
+        let launcher = temp.path().join("folder opener.cmd");
+        std::fs::write(folder.join("folder-marker"), "workspace contents").unwrap();
+        std::fs::write(
+            &launcher,
+            "@echo off\r\ncopy /y \"%~1\\folder-marker\" \"%~dp0received\" >nul\r\n",
+        )
+        .unwrap();
+        smol::block_on(crate::app::workspace_ops::open_workspace_folder(
+            launcher.to_str().unwrap(),
+            folder,
+        ))
+        .unwrap();
+        assert_eq!(
+            std::fs::read_to_string(temp.path().join("received")).unwrap(),
+            "workspace contents"
+        );
+    }
 
     #[test]
     fn helper_invocation_is_private_subcommand_only() {


### PR DESCRIPTION
## Summary

Workspace launches on Windows inherited Paneflow's process job and standard streams, while the file-manager action passed Explorer a combined `/select,<path>` argument. Launch external workspace commands with detached standard streams and explicit job breakaway, and pass Explorer the directory directly.

Refs #67

## User-visible behavior

- "Open in File Explorer" opens the workspace contents, including paths containing spaces.
- Editor and folder launches run off the UI thread. Menu actions and keyboard shortcuts continue to share their entry points.
- Logs record the resolved editor, directory, arguments, spawn errors, PID, and exit status. Failed editor launchers also produce a toast.

## Validation

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo deny check advisories licenses sources` (passed during implementation, with existing metadata warnings)
- [x] Maintainer reports that the change appears to work in a manual smoke check.

Windows regression tests cover native and batch launchers, job breakaway, workspace paths with spaces and Unicode, folder argument transmission, missing executables, and nonzero batch exit status. The original error 50 was not independently reproduced, and the manual check does not establish an exhaustive four-editor matrix.

## Cross-platform check

- [x] Linux: existing `xdg-open` path retained; source inspected for Wayland and X11. Not run on Linux.
- [x] macOS: existing `open` path retained; source inspected. Not run on Apple Silicon or Intel.
- [x] Windows: compiled and tested on Windows 11; Windows 10 not exercised.

## Screenshots / recordings

No capture available. The visual change is the Windows menu label.
