### PR TITLE
fix(agents): widen the profile env rows and expand $VAR in their values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ notes are available on the [GitHub Releases](https://github.com/arthjean/paneflo
   the config dumps reach `dsh` untouched. A harness install without the
   bridge package falls back to start, exit code, and end. Refs #60.
 
+### Fixed
+
+- Agent profile environment variables are readable and expand shell-style
+  names. The Environment variables control in Settings > Agents now takes the
+  full width of the editor instead of sharing a 300px column, so a name and a
+  path are both legible, and the remove button sits beside the value rather
+  than on top of its last characters. A value can now use `$NAME`, `${NAME}`,
+  or `%NAME%` alongside the existing leading `~`, each resolved against
+  Paneflow's own environment, with the resolved value shown under the row as
+  you type. A name your environment does not define is refused on save instead
+  of silently pointing the agent at a junk path. Refs #68.
+
 ## [0.14.0] - 2026-09-09
 
 ### Added

--- a/docs/user/configuration/schema.md
+++ b/docs/user/configuration/schema.md
@@ -119,7 +119,7 @@ CLI binary. `false` hides the button. `true` forces it visible.
 | `terminal.scrollback_lines` | integer/null | `10000` | New terminal | Range `100` to `100000`. Review terminals cap at `2000`; cached terminals cap at `1000`. |
 | `terminal.cursor_shape` | string/null | `block` | New terminal | `vintage`, `block`, `beam`, `underline`, `double_underline`, or `hollow`. |
 | `terminal.cursor_blink` | string/null | `terminal_controlled` | New terminal | `on`, `off`, or `terminal_controlled`. |
-| `terminal.env` | object/null | none | New terminal | Environment variables injected into every new terminal. Per-surface `env` wins. |
+| `terminal.env` | object/null | none | New terminal | Environment variables injected into every new terminal. Per-surface `env` wins. Values are passed through verbatim: no `~` and no `$NAME` expansion, unlike `agent_profiles.*.env`. |
 | `terminal.scroll_multiplier` | number/null | `1.0` | New terminal view | Range `0.1` to `10.0`. Ignored in mouse-reporting and alternate-screen scroll paths. |
 | `terminal.minimum_contrast` | number/null | `0.0` | Hot reload | Minimum APCA lightness contrast (Lc) enforced between text and its cell background, on the theme's ANSI colors only. `0` leaves theme colors untouched; Zed uses `45`. Range `0` to `90`. |
 
@@ -155,7 +155,7 @@ Settings > Agents > Profiles edits the same list.
 | --- | --- | --- | --- |
 | `agent_profiles.*.name` | string | required | Label shown in the launcher. |
 | `agent_profiles.*.agent` | string | required | Tag of the base agent: `claude_code`, `codex`, `opencode`, `pi`, `hermes`, `grok`, `amp`, `cursor`, `gemini`, `kiro`, `antigravity`, `copilot`, `codebuddy`, `factory`, `qoder`, or `openclaw`. |
-| `agent_profiles.*.env` | object | `{}` | Environment variables set on the agent process. A value starting with `~/` expands to the home directory. |
+| `agent_profiles.*.env` | object | `{}` | Environment variables set on the agent process. A leading `~` expands to the home directory, and `$NAME`, `${NAME}` or `%NAME%` anywhere in a value takes that variable from Paneflow's own environment. A `$` or `%` that names nothing stays literal; a name the environment does not define is refused by the Settings editor and, in a hand-written config, leaves the whole value untouched with a warning in the log. |
 | `agent_profiles.*.args` | string array | `[]` | Extra arguments appended after the base agent's own flags. Each token must be a plain word: letters, digits, `-`, `_`, `.`, `=`. |
 
 An entry with an unknown agent tag, a blank name, or an unsafe token is skipped

--- a/src-app/src/agent_launcher.rs
+++ b/src-app/src/agent_launcher.rs
@@ -600,9 +600,15 @@ impl AgentProfile {
 
     pub fn process_env(&self) -> HashMap<String, String> {
         let home = dirs::home_dir();
+        let lookup = |name: &str| std::env::var(name).ok();
         self.env
             .iter()
-            .map(|(key, value)| (key.clone(), expand_home(value, home.as_deref())))
+            .map(|(key, value)| {
+                (
+                    key.clone(),
+                    expand_profile_value(key, value, home.as_deref(), &lookup),
+                )
+            })
             .collect()
     }
 }
@@ -613,19 +619,20 @@ fn is_env_key(key: &str) -> bool {
         && key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
-fn expand_home(value: &str, home: Option<&std::path::Path>) -> String {
-    let Some(home) = home else {
-        return value.to_string();
-    };
-    if value == "~" {
-        return home.display().to_string();
-    }
-    match value
-        .strip_prefix("~/")
-        .or_else(|| value.strip_prefix("~\\"))
-    {
-        Some(rest) => home.join(rest).display().to_string(),
-        None => value.to_string(),
+fn expand_profile_value(
+    key: &str,
+    value: &str,
+    home: Option<&std::path::Path>,
+    lookup: &dyn Fn(&str) -> Option<String>,
+) -> String {
+    match crate::env_expand::expand_env_value(value, home, lookup) {
+        Ok(expanded) => expanded,
+        Err(name) => {
+            log::warn!(
+                "agent_profiles: '{key}' references '{name}', which is not set; passing the value through unchanged"
+            );
+            value.to_string()
+        }
     }
 }
 
@@ -997,16 +1004,35 @@ mod tests {
     }
 
     #[test]
-    fn profile_env_expands_leading_tilde_only() {
+    fn profile_env_expands_the_home_prefix_and_known_placeholders() {
         let home = std::path::Path::new("/home/u");
+        let lookup = |name: &str| (name == "BASE").then(|| "/opt/base".to_string());
         assert_eq!(
-            expand_home("~/.claude-perso", Some(home)),
+            expand_profile_value("K", "~/.claude-perso", Some(home), &lookup),
             home.join(".claude-perso").display().to_string()
         );
-        assert_eq!(expand_home("~", Some(home)), "/home/u");
-        assert_eq!(expand_home("~user/x", Some(home)), "~user/x");
-        assert_eq!(expand_home("/abs/~/x", Some(home)), "/abs/~/x");
-        assert_eq!(expand_home("~/x", None), "~/x");
+        assert_eq!(
+            expand_profile_value("K", "$BASE/x", Some(home), &lookup),
+            "/opt/base/x"
+        );
+        assert_eq!(
+            expand_profile_value("K", "%BASE%/x", Some(home), &lookup),
+            "/opt/base/x"
+        );
+    }
+
+    #[test]
+    fn profile_env_passes_an_unresolvable_value_through_unchanged() {
+        let home = std::path::Path::new("/home/u");
+        let lookup = |_: &str| None;
+        assert_eq!(
+            expand_profile_value("K", "$NOPE/.claude-perso", Some(home), &lookup),
+            "$NOPE/.claude-perso"
+        );
+        assert_eq!(
+            expand_profile_value("K", "a%b%c", Some(home), &lookup),
+            "a%b%c"
+        );
     }
 
     #[test]

--- a/src-app/src/env_expand.rs
+++ b/src-app/src/env_expand.rs
@@ -1,0 +1,200 @@
+use std::path::Path;
+
+pub(crate) fn expand_env_value<F>(
+    value: &str,
+    home: Option<&Path>,
+    lookup: F,
+) -> Result<String, String>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    expand_placeholders(&expand_leading_home(value, home), &lookup)
+}
+
+pub(crate) fn expand_with_process_env(value: &str, home: Option<&Path>) -> Result<String, String> {
+    expand_env_value(value, home, |name| std::env::var(name).ok())
+}
+
+fn expand_leading_home(value: &str, home: Option<&Path>) -> String {
+    let Some(home) = home else {
+        return value.to_string();
+    };
+    if value == "~" {
+        return home.display().to_string();
+    }
+    match value
+        .strip_prefix("~/")
+        .or_else(|| value.strip_prefix("~\\"))
+    {
+        Some(rest) => home.join(rest).display().to_string(),
+        None => value.to_string(),
+    }
+}
+
+fn expand_placeholders<F>(value: &str, lookup: &F) -> Result<String, String>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let bytes = value.as_bytes();
+    let mut out = String::with_capacity(value.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        let next = value[index..]
+            .find(['$', '%'])
+            .map_or(bytes.len(), |offset| index + offset);
+        if next > index {
+            out.push_str(&value[index..next]);
+            index = next;
+            continue;
+        }
+        match bytes[index] {
+            b'$' if bytes.get(index + 1) == Some(&b'{') => match braced_name(value, index + 2) {
+                Some((name, end)) => {
+                    out.push_str(&resolve(name, lookup)?);
+                    index = end;
+                }
+                None => {
+                    out.push('$');
+                    index += 1;
+                }
+            },
+            b'$' => {
+                let name = identifier_at(value, index + 1);
+                if name.is_empty() {
+                    out.push('$');
+                    index += 1;
+                } else {
+                    out.push_str(&resolve(name, lookup)?);
+                    index += 1 + name.len();
+                }
+            }
+            _ => {
+                let name = identifier_at(value, index + 1);
+                let end = index + 1 + name.len();
+                if !name.is_empty() && bytes.get(end) == Some(&b'%') {
+                    out.push_str(&resolve(name, lookup)?);
+                    index = end + 1;
+                } else {
+                    out.push('%');
+                    index += 1;
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn braced_name(value: &str, start: usize) -> Option<(&str, usize)> {
+    let rest = value.get(start..)?;
+    let close = rest.find('}')?;
+    let name = &rest[..close];
+    is_placeholder_name(name).then_some((name, start + close + 1))
+}
+
+fn identifier_at(value: &str, start: usize) -> &str {
+    let rest = value.get(start..).unwrap_or_default();
+    let len = rest
+        .bytes()
+        .take_while(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
+        .count();
+    let candidate = &rest[..len];
+    if is_placeholder_name(candidate) {
+        candidate
+    } else {
+        ""
+    }
+}
+
+fn is_placeholder_name(name: &str) -> bool {
+    let mut bytes = name.bytes();
+    matches!(bytes.next(), Some(b'A'..=b'Z' | b'a'..=b'z' | b'_'))
+        && bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+}
+
+fn resolve<F>(name: &str, lookup: &F) -> Result<String, String>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    lookup(name).ok_or_else(|| name.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lookup(name: &str) -> Option<String> {
+        match name {
+            "USERPROFILE" => Some("C:\\Users\\u".to_string()),
+            "HOME" => Some("/home/u".to_string()),
+            "EMPTY" => Some(String::new()),
+            _ => None,
+        }
+    }
+
+    fn expand(value: &str) -> Result<String, String> {
+        expand_env_value(value, Some(Path::new("/home/u")), lookup)
+    }
+
+    #[test]
+    fn leading_tilde_expands_only_at_the_start() {
+        let home = Path::new("/home/u");
+        assert_eq!(
+            expand_env_value("~/.claude-perso", Some(home), lookup).unwrap(),
+            home.join(".claude-perso").display().to_string()
+        );
+        assert_eq!(
+            expand_env_value("~", Some(home), lookup).unwrap(),
+            "/home/u"
+        );
+        assert_eq!(
+            expand_env_value("~user/x", Some(home), lookup).unwrap(),
+            "~user/x"
+        );
+        assert_eq!(
+            expand_env_value("/abs/~/x", Some(home), lookup).unwrap(),
+            "/abs/~/x"
+        );
+        assert_eq!(expand_env_value("~/x", None, lookup).unwrap(), "~/x");
+    }
+
+    #[test]
+    fn every_supported_syntax_expands_against_the_lookup() {
+        assert_eq!(expand("$HOME/x").unwrap(), "/home/u/x");
+        assert_eq!(expand("${HOME}/x").unwrap(), "/home/u/x");
+        assert_eq!(
+            expand("%USERPROFILE%\\.claude-perso").unwrap(),
+            "C:\\Users\\u\\.claude-perso"
+        );
+        assert_eq!(expand("$HOME:${HOME}").unwrap(), "/home/u:/home/u");
+        assert_eq!(expand("$EMPTY").unwrap(), "");
+    }
+
+    #[test]
+    fn an_unknown_name_is_reported_instead_of_expanding_to_nothing() {
+        assert_eq!(expand("$NOPE/x"), Err("NOPE".to_string()));
+        assert_eq!(expand("${NOPE}"), Err("NOPE".to_string()));
+        assert_eq!(expand("%NOPE%"), Err("NOPE".to_string()));
+    }
+
+    #[test]
+    fn a_marker_that_names_nothing_stays_literal() {
+        assert_eq!(expand("100%").unwrap(), "100%");
+        assert_eq!(expand("50% off").unwrap(), "50% off");
+        assert_eq!(expand("$ ").unwrap(), "$ ");
+        assert_eq!(expand("$1").unwrap(), "$1");
+        assert_eq!(expand("${}").unwrap(), "${}");
+        assert_eq!(expand("${not a name}").unwrap(), "${not a name}");
+        assert_eq!(expand("a$").unwrap(), "a$");
+        assert_eq!(expand("%%").unwrap(), "%%");
+        assert_eq!(expand("100% of $HOME").unwrap(), "100% of /home/u");
+    }
+
+    #[test]
+    fn expansion_is_not_applied_to_what_a_lookup_returned() {
+        let expanded = expand_env_value("$TILDE/x", Some(Path::new("/home/u")), |name| {
+            (name == "TILDE").then(|| "~".to_string())
+        })
+        .unwrap();
+        assert_eq!(expanded, "~/x");
+    }
+}

--- a/src-app/src/main.rs
+++ b/src-app/src/main.rs
@@ -26,6 +26,7 @@ mod command_sessions;
 mod config_writer;
 mod diff;
 mod editor;
+mod env_expand;
 mod external_open;
 mod file_icons;
 mod fonts;

--- a/src-app/src/settings/tabs/agents.rs
+++ b/src-app/src/settings/tabs/agents.rs
@@ -20,6 +20,7 @@ use crate::widgets::text_input::TextInput;
 
 const ROW_ICON: f32 = 18.;
 const CONTROL_WIDTH: f32 = 300.;
+const ENV_NAME_WIDTH: f32 = 200.;
 const INPUT_HEIGHT: f32 = 28.;
 const ICON_BUTTON_SIZE: f32 = 26.;
 const AGENT_ROW_HEIGHT: f32 = 44.;
@@ -486,81 +487,86 @@ impl PaneFlowApp {
     ) -> AnyElement {
         let base_select = self.render_agent_profile_base_select(editor, ui, cx);
 
-        let mut env_column = div()
-            .flex()
-            .flex_col()
-            .items_end()
-            .gap(px(6.))
-            .w(px(CONTROL_WIDTH));
+        let home = dirs::home_dir();
+        let row_values: Vec<String> = editor
+            .env_rows
+            .iter()
+            .map(|row| row.value.read(cx).value())
+            .collect();
+
+        let mut env_column = div().flex().flex_col().gap(px(6.)).w_full();
         for (row_idx, row) in editor.env_rows.iter().enumerate() {
             let removable = editor.env_rows.len() > 1;
+            let hint = row_values
+                .get(row_idx)
+                .and_then(|value| env_value_hint(value, home.as_deref(), ui));
             env_column = env_column.child(
                 div()
                     .flex()
-                    .flex_row()
-                    .items_center()
-                    .gap(px(6.))
+                    .flex_col()
+                    .gap(px(3.))
                     .w_full()
                     .child(
                         div()
-                            .flex_1()
-                            .min_w_0()
-                            .child(input_box(row.key.clone(), true, ui)),
-                    )
-                    .child(
-                        div()
-                            .flex_1()
-                            .min_w_0()
-                            .relative()
-                            .child(input_box(row.value.clone(), true, ui))
+                            .flex()
+                            .flex_row()
+                            .items_center()
+                            .gap(px(6.))
+                            .w_full()
+                            .child(div().w(px(ENV_NAME_WIDTH)).flex_none().child(input_box(
+                                row.key.clone(),
+                                true,
+                                ui,
+                            )))
+                            .child(div().flex_1().min_w_0().child(input_box(
+                                row.value.clone(),
+                                true,
+                                ui,
+                            )))
                             .when(removable, |d| {
                                 d.child(
-                                    div()
-                                        .absolute()
-                                        .top(px((INPUT_HEIGHT - ICON_BUTTON_SIZE) / 2.))
-                                        .right(px(1.))
-                                        .child(
-                                            icon_button(
-                                                SharedString::from(format!(
-                                                    "agent-profile-env-remove-{row_idx}"
-                                                )),
-                                                "icons/trash.svg",
-                                                ui.muted,
-                                                destructive_color(),
-                                                ui,
-                                            )
-                                            .on_click(
-                                                cx.listener(move |this, _: &ClickEvent, _w, cx| {
-                                                    if let Some(editor) =
-                                                        this.agent_profile_editor.as_mut()
-                                                        && row_idx < editor.env_rows.len()
-                                                    {
-                                                        editor.env_rows.remove(row_idx);
-                                                        cx.notify();
-                                                    }
-                                                }),
-                                            ),
-                                        ),
+                                    icon_button(
+                                        SharedString::from(format!(
+                                            "agent-profile-env-remove-{row_idx}"
+                                        )),
+                                        "icons/trash.svg",
+                                        ui.muted,
+                                        destructive_color(),
+                                        ui,
+                                    )
+                                    .on_click(cx.listener(
+                                        move |this, _: &ClickEvent, _w, cx| {
+                                            if let Some(editor) = this.agent_profile_editor.as_mut()
+                                                && row_idx < editor.env_rows.len()
+                                            {
+                                                editor.env_rows.remove(row_idx);
+                                                cx.notify();
+                                            }
+                                        },
+                                    )),
                                 )
                             }),
-                    ),
+                    )
+                    .when_some(hint, |d, hint| d.child(hint)),
             );
         }
         env_column = env_column.child(
-            div()
-                .id("agent-profile-env-add")
-                .flex_none()
-                .px(px(6.))
-                .py(px(2.))
-                .rounded(SETTINGS_CONTROL_CORNER_RADIUS)
-                .cursor(CursorStyle::PointingHand)
-                .text_size(LABEL_SM)
-                .text_color(ui.muted)
-                .animated_hover_bg(with_alpha(ui.text, 0.0), with_alpha(ui.text, 0.05))
-                .on_click(cx.listener(|this, _: &ClickEvent, _w, cx| {
-                    this.add_agent_profile_env_row(cx);
-                }))
-                .child("+ Add variable"),
+            div().flex().flex_row().child(
+                div()
+                    .id("agent-profile-env-add")
+                    .flex_none()
+                    .px(px(6.))
+                    .py(px(2.))
+                    .rounded(SETTINGS_CONTROL_CORNER_RADIUS)
+                    .cursor(CursorStyle::PointingHand)
+                    .text_size(LABEL_SM)
+                    .text_color(ui.muted)
+                    .animated_hover_bg(with_alpha(ui.text, 0.0), with_alpha(ui.text, 0.05))
+                    .on_click(cx.listener(|this, _: &ClickEvent, _w, cx| {
+                        this.add_agent_profile_env_row(cx);
+                    }))
+                    .child("+ Add variable"),
+            ),
         );
 
         let footer_text: AnyElement = match editor.error.as_ref() {
@@ -630,9 +636,10 @@ impl PaneFlowApp {
                 ui,
             ))
             .child(hairline(ui))
-            .child(editor_row(
+            .child(editor_stacked_row(
                 "Environment variables",
-                "Set on the agent process. A leading ~ expands to your home.",
+                "Set on the agent process. A leading ~ is your home, and $NAME, ${NAME} or \
+                 %NAME% takes the value from your environment.",
                 env_column,
                 ui,
             ))
@@ -907,7 +914,9 @@ impl PaneFlowApp {
             .map(|row| (row.key.read(cx).value(), row.value.read(cx).value()))
             .collect();
 
+        let home = dirs::home_dir();
         let draft = collect_env(&raw_env).and_then(|env| {
+            validate_env_values(&env, home.as_deref())?;
             let entry = AgentProfileConfig {
                 name: name.trim().to_string(),
                 agent: agent.tag().to_string(),
@@ -974,6 +983,20 @@ fn new_env_row(key: &str, value: &str, cx: &mut Context<PaneFlowApp>) -> EnvRowI
     EnvRowInputs { key, value }
 }
 
+fn validate_env_values(
+    env: &BTreeMap<String, String>,
+    home: Option<&std::path::Path>,
+) -> Result<(), String> {
+    for (key, value) in env {
+        if let Err(name) = crate::env_expand::expand_with_process_env(value, home) {
+            return Err(format!(
+                "'{key}' references {name}, which is not set in your environment"
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn collect_env(rows: &[(String, String)]) -> Result<BTreeMap<String, String>, String> {
     let mut env = BTreeMap::new();
     for (key, value) in rows {
@@ -1007,6 +1030,56 @@ fn editor_row(
         .py(px(10.))
         .child(setting_text(ui, title, description))
         .child(div().flex_shrink_0().child(control))
+}
+
+fn editor_stacked_row(
+    title: &'static str,
+    description: &'static str,
+    control: impl IntoElement,
+    ui: crate::theme::UiColors,
+) -> impl IntoElement {
+    div()
+        .flex()
+        .flex_col()
+        .gap(px(10.))
+        .px(px(12.))
+        .py(px(10.))
+        .child(
+            div()
+                .flex()
+                .flex_row()
+                .child(setting_text(ui, title, description)),
+        )
+        .child(control)
+}
+
+fn env_value_hint(
+    value: &str,
+    home: Option<&std::path::Path>,
+    ui: crate::theme::UiColors,
+) -> Option<AnyElement> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    let base = div()
+        .pl(px(ENV_NAME_WIDTH + 6.))
+        .text_size(LABEL_XS)
+        .truncate();
+    match crate::env_expand::expand_with_process_env(value, home) {
+        Ok(expanded) if expanded == value => None,
+        Ok(expanded) => Some(
+            base.font_family(mono_family())
+                .text_color(ui.muted)
+                .child(expanded)
+                .into_any_element(),
+        ),
+        Err(name) => Some(
+            base.text_color(destructive_color())
+                .child(format!("{name} is not set in your environment"))
+                .into_any_element(),
+        ),
+    }
 }
 
 fn mono_family() -> SharedString {
@@ -1125,5 +1198,20 @@ mod tests {
             ])
             .is_err()
         );
+    }
+
+    #[test]
+    fn validate_env_values_rejects_a_name_the_environment_does_not_define() {
+        let known = BTreeMap::from([("A".to_string(), "$PATH".to_string())]);
+        assert!(validate_env_values(&known, None).is_ok());
+        let literal = BTreeMap::from([("A".to_string(), "~/.claude-perso".to_string())]);
+        assert!(validate_env_values(&literal, None).is_ok());
+        let unknown = BTreeMap::from([(
+            "CLAUDE_CONFIG_DIR".to_string(),
+            "$PANEFLOW_NOT_A_REAL_VARIABLE/x".to_string(),
+        )]);
+        let error = validate_env_values(&unknown, None).unwrap_err();
+        assert!(error.contains("CLAUDE_CONFIG_DIR"), "{error}");
+        assert!(error.contains("PANEFLOW_NOT_A_REAL_VARIABLE"), "{error}");
     }
 }


### PR DESCRIPTION
Fixes both defects reported in #68, in Settings > Agents > agent profile editor.

## 1. The environment variable rows were too narrow for their own content

The control shared the 300px right-hand column with its label, so the name and
the value got roughly 147px each, and the remove button was absolutely
positioned over the right edge of the value input, costing it another 26px. A
path or a URL, which is what these values almost always are, showed about its
first twenty characters.

The row is now stacked: title and description on their own line, then the
`name` / `value` pairs at full editor width, then `+ Add variable`. The name
takes a fixed 200px and the value takes the rest, since a variable name is
bounded by convention and its value is not. The remove button moved out of the
value input into its own slot, so it no longer sits on top of the text, and it
is only laid out when there is more than one row, so a single row runs to the
same right edge as `Base agent`, `Name` and `Extra arguments`.

Concretely, inside the 620px of editor content the value input goes from about
121px of visible text to 414px with one row, and 382px once a second row brings
the remove buttons in. Every other row of the editor keeps the existing
side-by-side layout.

## 2. `$USERPROFILE` in a value was passed through literally

Only a leading `~` was expanded, so `$USERPROFILE/.claude-perso` reached the
agent verbatim and silently pointed `CLAUDE_CONFIG_DIR` at a directory that
does not exist. Claude Code does not expand it either.

A new `src-app/src/env_expand.rs` holds one parser: a leading `~` as before,
plus `$NAME`, `${NAME}` and `%NAME%` anywhere in the value, resolved against
Paneflow's own environment. A `$` or `%` that names nothing stays literal, and
expansion is never reapplied to what a lookup returned.

The two call sites deliberately differ:

- **On save**, an unknown name is refused with the editor's error, and the
  config keeps the raw value so the profile stays portable. Each row also shows
  its resolved value underneath as you type, in muted mono, or the failure in
  red. That inline feedback is the actual cure for the silent failure, and it
  is what the full-width layout makes room for.
- **At launch**, an unknown name leaves the whole value untouched and logs a
  warning. Never an empty string, and never a failed launch, so a saved profile
  whose value happens to contain a paired `%` cannot start breaking.

## The inconsistency the issue asked to resolve

`terminal.env` reaches the PTY with no expansion at all. Moving the expansion
down into `assemble_pty_env` would cover all three env surfaces at once, and I
deliberately did not: it would silently change the meaning of existing
`terminal.env` values with no editor to show the result and no validation
surface, and `${...}` is already taken at that layer by the flow spec, where
`up_cmd.rs` rejects every token but `${port_offset}`. A second `${}` meaning
underneath that is exactly the trap the issue warns about.

Resolved by documentation instead: `docs/user/configuration/schema.md` now
states the rule on both the `terminal.env` and `agent_profiles.*.env` rows, and
the editor's own description names the supported syntax. A leading `~` remains
the portable form and the one the description leads with.

## Known limitation, not addressed here

`TextInput` paints its line from `bounds.left()` with no scroll offset
(`src-app/src/widgets/text_input.rs:578`), so a value longer than the visible
box still clips and the caret leaves the field while editing. Widening the row
moves the threshold well past a normal absolute path but does not remove it.
Fixing it touches every input in the app, so it belongs in its own issue.

## Validation

Run from the repository root on Windows 11 x86_64:

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

All three pass. Eight new tests cover the parser (each supported syntax, the
unknown name, the markers that name nothing, and that a lookup result is not
re-expanded), the launch-time pass-through, and the save-time refusal.

No dependency change, so `cargo deny` was not run.

The `#[cfg(windows)]` note in AGENTS.md does not apply: nothing here is
platform-gated. The layout half is platform-independent and the expansion is
cross-platform, with `%NAME%` resolving case-insensitively on Windows through
`std::env::var`.

Screenshot of the editor with one and two variable rows to follow.

Refs #68
